### PR TITLE
Add Todoist Task Manager (Agent Visibility) use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-10-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-11-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 </div>
 
@@ -42,6 +42,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |
 | [Health & Symptom Tracker](usecases/health-symptom-tracker.md) | Track food intake and symptoms to identify triggers, with scheduled check-in reminders. |
 | [Multi-Channel Personal Assistant](usecases/multi-channel-assistant.md) | Route tasks across Telegram, Slack, email, and calendar from a single AI assistant. |
+| [Todoist Task Manager](usecases/todoist-task-manager.md) | Maximize agent transparency by syncing reasoning and progress logs to Todoist. |
 
 ## Research & Learning
 

--- a/usecases/todoist-task-manager.md
+++ b/usecases/todoist-task-manager.md
@@ -1,0 +1,118 @@
+# Todoist Task Manager: Agent Task Visibility
+Maximize transparency for long-running agentic workflows by syncing internal reasoning and progress logs directly to Todoist.
+
+## Pain Point
+When agents run complex, multi-step tasks (like building a full-stack app or performing deep research), the user often loses track of what the agent is currently doing, what steps have been completed, and where the agent might be stuck. Checking chat logs manually is tedious for background tasks.
+
+## What It Does
+This use case uses the `todoist-task-manager` skill to:
+1.  **Visualize State**: Create tasks in specific sections like `🟡 In Progress` or `🟠 Waiting`.
+2.  **Externalize Reasoning**: Post the agent's internal "Plan" into the task description.
+3.  **Stream Logs**: Add sub-step completions as comments to the task in real-time.
+4.  **Auto-Reconcile**: A heartbeat script checks for stalled tasks and notifies the user.
+
+## Skills you Need
+You don't need a pre-built skill. Simply prompt your OpenClaw agent to create the bash scripts described in the **Setup Guide** below. Since OpenClaw can manage its own filesystem and execute shell commands, it will effectively "build" the skill for you upon request.
+
+## Detailed Setup Guide
+
+### 1. Configure Todoist
+Create a project (e.g., "OpenClaw Workspace") and get its ID. Create sections for different states:
+- `🟡 In Progress`
+- `🟠 Waiting`
+- `🟢 Done`
+
+### 2. Implementation: The "Agent-Built" Skill
+Instead of installing a skill, you can ask OpenClaw to create these scripts for you. Each script handles a different part of the communication with the Todoist API.
+
+**`scripts/todoist_api.sh`** (The Core Wrapper):
+```bash
+#!/bin/bash
+# Usage: ./todoist_api.sh <endpoint> <method> [data_json]
+ENDPOINT=$1
+METHOD=$2
+DATA=$3
+TOKEN="YOUR_TODOIST_API_TOKEN"
+
+if [ -z "$DATA" ]; then
+  curl -s -X "$METHOD" "https://api.todoist.com/rest/v2/$ENDPOINT" \
+    -H "Authorization: Bearer $TOKEN"
+else
+  curl -s -X "$METHOD" "https://api.todoist.com/rest/v2/$ENDPOINT" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$DATA"
+fi
+```
+
+**`scripts/sync_task.sh`** (Task & Status Management):
+```bash
+#!/bin/bash
+# Usage: ./sync_task.sh <task_content> <status> [task_id] [description] [labels_json_array]
+CONTENT=$1
+STATUS=$2
+TASK_ID=$3
+DESCRIPTION=$4
+LABELS=$5
+PROJECT_ID="YOUR_PROJECT_ID"
+
+case $STATUS in
+  "In Progress") SECTION_ID="SECTION_ID_PROGRESS" ;;
+  "Waiting")     SECTION_ID="SECTION_ID_WAITING" ;;
+  "Done")        SECTION_ID="SECTION_ID_DONE" ;;
+  *)             SECTION_ID="" ;;
+esac
+
+PAYLOAD="{\"content\": \"$CONTENT\""
+[ -n "$SECTION_ID" ] && PAYLOAD="$PAYLOAD, \"section_id\": \"$SECTION_ID\""
+[ -n "$PROJECT_ID" ] && [ -z "$TASK_ID" ] && PAYLOAD="$PAYLOAD, \"project_id\": \"$PROJECT_ID\""
+if [ -n "$DESCRIPTION" ]; then
+  ESC_DESC=$(echo "$DESCRIPTION" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
+  PAYLOAD="$PAYLOAD, \"description\": \"$ESC_DESC\""
+fi
+[ -n "$LABELS" ] && PAYLOAD="$PAYLOAD, \"labels\": $LABELS"
+PAYLOAD="$PAYLOAD}"
+
+if [ -n "$TASK_ID" ]; then
+  ./scripts/todoist_api.sh "tasks/$TASK_ID" POST "$PAYLOAD"
+else
+  ./scripts/todoist_api.sh "tasks" POST "$PAYLOAD"
+fi
+```
+
+**`scripts/add_comment.sh`** (Progress Logging):
+```bash
+#!/bin/bash
+# Usage: ./add_comment.sh <task_id> <comment_text>
+TASK_ID=$1
+TEXT=$2
+ESC_TEXT=$(echo "$TEXT" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
+PAYLOAD="{\"task_id\": \"$TASK_ID\", \"content\": \"$ESC_TEXT\"}"
+./scripts/todoist_api.sh "comments" POST "$PAYLOAD"
+```
+
+### 3. Usage Prompt
+You can give this prompt to your agent to both **setup** and **use** the visibility system:
+
+```text
+I want you to build a Todoist-based task visibility system for your own runs. 
+
+First, create three bash scripts in a 'scripts/' folder: 
+1. todoist_api.sh (a curl wrapper for Todoist REST API)
+2. sync_task.sh (to create or update tasks with specific section_ids for In Progress, Waiting, and Done)
+3. add_comment.sh (to post progress logs as comments)
+
+Use these variables for the setup:
+- Token: [Your Todoist API Token]
+- Project ID: [Your Project ID]
+- Section IDs: [In Progress ID, Waiting ID, Done ID]
+
+Once created, for every complex task I give you:
+1. Create a task in 'In Progress' with your full PLAN in the description.
+2. For every sub-step completion, call add_comment.sh with a log of what you did.
+3. Move the task to 'Done' when finished.
+```
+
+## Related Links
+- [Todoist REST API Documentation](https://developer.todoist.com/rest/v2/)
+


### PR DESCRIPTION
This PR adds a new use case focused on Agent Task Visibility using Todoist.

While many use cases focus on the agent doing work for the user, this one addresses a critical bottleneck in agentic workflows: Transparency. It provides a framework for agents to "externalize" their internal reasoning and progress logs directly into a Todoist project.

Key features of this use case:

• Progress Streaming: Shows how to use Todoist comments as a real-time log for multi-step agent tasks.
• State Management: Uses Todoist sections (In Progress, Waiting, Done) to give the user a high-level dashboard of what the agent is currently tackling.

Content Added:

• usecases/todoist-task-manager.md: Detailed guide, prompts, and bash script logic.
• README.md: Added to the Productivity section and updated the use case count.

I have verified this workflow locally been using it for 2 days and it has definitely helped with the black box problem.