### PR TITLE
Add 3 real-world OpenClaw use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-10-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-13-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 </div>
 
@@ -42,6 +42,8 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |
 | [Health & Symptom Tracker](usecases/health-symptom-tracker.md) | Track food intake and symptoms to identify triggers, with scheduled check-in reminders. |
 | [Multi-Channel Personal Assistant](usecases/multi-channel-assistant.md) | Route tasks across Telegram, Slack, email, and calendar from a single AI assistant. |
+| [Project State Management](usecases/project-state-management.md) | Event-driven project tracking with automatic context capture, replacing static Kanban boards. |
+| [Dynamic Dashboard](usecases/dynamic-dashboard.md) | Real-time dashboard with parallel data fetching from APIs, databases, and social media. |
 
 ## Research & Learning
 
@@ -49,6 +51,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [AI Earnings Tracker](usecases/earnings-tracker.md) | Track tech/AI earnings reports with automated previews, alerts, and detailed summaries. |
 | [Personal Knowledge Base (RAG)](usecases/knowledge-base-rag.md) | Build a searchable knowledge base by dropping URLs, tweets, and articles into chat. |
+
+## Finance & Trading
+
+| Name | Description |
+|------|-------------|
+| [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
 
 ## 🤝 Contributing
 

--- a/usecases/dynamic-dashboard.md
+++ b/usecases/dynamic-dashboard.md
@@ -1,0 +1,113 @@
+# Dynamic Dashboard with Sub-agent Spawning
+
+Static dashboards show stale data and require constant manual updates. You want real-time visibility across multiple data sources without building a custom frontend or hitting API rate limits.
+
+This workflow creates a live dashboard that spawns sub-agents to fetch and process data in parallel:
+
+• Monitors multiple data sources simultaneously (APIs, databases, GitHub, social media)
+• Spawns sub-agents for each data source to avoid blocking and distribute API load
+• Aggregates results into a unified dashboard (text, HTML, or Canvas)
+• Updates every N minutes with fresh data
+• Sends alerts when metrics cross thresholds
+• Maintains historical trends in a database for visualization
+
+## Pain Point
+
+Building a custom dashboard takes weeks. By the time it's done, requirements have changed. Polling multiple APIs sequentially is slow and hits rate limits. You need insight now, not after a weekend of coding.
+
+## What It Does
+
+You define what you want to monitor conversationally: "Track GitHub stars, Twitter mentions, Polymarket volume, and system health." OpenClaw spawns sub-agents to fetch each data source in parallel, aggregates the results, and delivers a formatted dashboard to Discord or as an HTML file. Updates run automatically on a cron schedule.
+
+Example dashboard sections:
+- **GitHub**: stars, forks, open issues, recent commits
+- **Social Media**: Twitter mentions, Reddit discussions, Discord activity
+- **Markets**: Polymarket volume, prediction trends
+- **System Health**: CPU, memory, disk usage, service status
+
+## Skills Needed
+
+- Sub-agent spawning for parallel execution
+- `github` (gh CLI) for GitHub metrics
+- `bird` (Twitter) for social data
+- `web_search` or `web_fetch` for external APIs
+- `postgres` for storing historical metrics
+- Discord or Canvas for rendering the dashboard
+- Cron jobs for scheduled updates
+
+## How to Set it Up
+
+1. Set up a metrics database:
+```sql
+CREATE TABLE metrics (
+  id SERIAL PRIMARY KEY,
+  source TEXT, -- e.g., "github", "twitter", "polymarket"
+  metric_name TEXT,
+  metric_value NUMERIC,
+  timestamp TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE alerts (
+  id SERIAL PRIMARY KEY,
+  source TEXT,
+  condition TEXT,
+  threshold NUMERIC,
+  last_triggered TIMESTAMPTZ
+);
+```
+
+2. Create a Discord channel for dashboard updates (e.g., #dashboard).
+
+3. Prompt OpenClaw:
+```text
+You are my dynamic dashboard manager. Every 15 minutes, run a cron job to:
+
+1. Spawn sub-agents in parallel to fetch data from:
+   - GitHub: stars, forks, open issues, commits (past 24h)
+   - Twitter: mentions of "@username", sentiment analysis
+   - Polymarket: volume for tracked markets
+   - System: CPU, memory, disk usage via shell commands
+
+2. Each sub-agent writes results to the metrics database.
+
+3. Aggregate all results and format a dashboard:
+
+📊 **Dashboard Update** — [timestamp]
+
+**GitHub**
+- ⭐ Stars: [count] (+[change])
+- 🍴 Forks: [count]
+- 🐛 Open Issues: [count]
+- 💻 Commits (24h): [count]
+
+**Social Media**
+- 🐦 Twitter Mentions: [count]
+- 📈 Sentiment: [positive/negative/neutral]
+
+**Markets**
+- 📊 Polymarket Volume: $[amount]
+- 🔥 Trending: [market names]
+
+**System Health**
+- 💻 CPU: [usage]%
+- 🧠 Memory: [usage]%
+- 💾 Disk: [usage]%
+
+4. Post to Discord #dashboard.
+
+5. Check alert conditions:
+   - If GitHub stars change > 50 in 1 hour → ping me
+   - If system CPU > 90% → alert
+   - If negative sentiment spike on Twitter → notify
+
+Store all metrics in the database for historical analysis.
+```
+
+4. Optional: Use Canvas to render an HTML dashboard with charts and graphs.
+
+5. Query historical data: "Show me GitHub star growth over the past 30 days."
+
+## Related Links
+
+- [Parallel Processing with Sub-agents](https://docs.openclaw.ai/subagents)
+- [Dashboard Design Principles](https://www.nngroup.com/articles/dashboard-design/)

--- a/usecases/polymarket-autopilot.md
+++ b/usecases/polymarket-autopilot.md
@@ -1,0 +1,90 @@
+# Polymarket Autopilot: Automated Paper Trading
+
+Manually monitoring prediction markets for arbitrage opportunities and executing trades is time-consuming and requires constant attention. You want to test and refine trading strategies without risking real capital.
+
+This workflow automates paper trading on Polymarket with custom strategies:
+
+• Monitors market data via API (prices, volume, spreads)
+• Executes paper trades using TAIL (trend-following) and BONDING (contrarian) strategies
+• Tracks portfolio performance, P&L, and win rate
+• Delivers daily summaries to Discord with trade logs and insights
+• Learns from patterns: adjusts strategy parameters based on backtesting results
+
+## Pain Point
+
+Prediction markets move fast. Manual trading means missing opportunities, emotional decisions, and difficulty tracking what works. Testing strategies with real money risks losses before you understand market behavior.
+
+## What It Does
+
+The autopilot continuously scans Polymarket for opportunities, simulates trades using configurable strategies, and logs everything for analysis. You wake up to a summary of what it "traded" overnight, what worked, and what didn't.
+
+Example strategies:
+- **TAIL**: Follow trends when volume spikes and momentum is clear
+- **BONDING**: Buy contrarian positions when markets overreact to news
+- **SPREAD**: Identify mispriced markets with arbitrage potential
+
+## Skills Needed
+
+- `web_search` or `web_fetch` (for Polymarket API data)
+- `postgres` or SQLite for trade logs and portfolio tracking
+- Discord integration for daily reports
+- Cron jobs for continuous monitoring
+- Sub-agent spawning for parallel market analysis
+
+## How to Set it Up
+
+1. Set up a database for paper trading:
+```sql
+CREATE TABLE paper_trades (
+  id SERIAL PRIMARY KEY,
+  market_id TEXT,
+  market_name TEXT,
+  strategy TEXT,
+  direction TEXT,
+  entry_price DECIMAL,
+  exit_price DECIMAL,
+  quantity DECIMAL,
+  pnl DECIMAL,
+  timestamp TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE portfolio (
+  id SERIAL PRIMARY KEY,
+  total_value DECIMAL,
+  cash DECIMAL,
+  positions JSONB,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+2. Create a Discord channel for updates (e.g., #polymarket-autopilot).
+
+3. Prompt OpenClaw:
+```text
+You are a Polymarket paper trading autopilot. Run continuously (via cron every 15 minutes):
+
+1. Fetch current market data from Polymarket API
+2. Analyze opportunities using these strategies:
+   - TAIL: Follow strong trends (>60% probability + volume spike)
+   - BONDING: Contrarian plays on overreactions (sudden drops >10% on news)
+   - SPREAD: Arbitrage when YES+NO > 1.05
+3. Execute paper trades in the database (starting capital: $10,000)
+4. Track portfolio state and update positions
+
+Every morning at 8 AM, post a summary to Discord #polymarket-autopilot:
+- Yesterday's trades (entry/exit prices, P&L)
+- Current portfolio value and open positions
+- Win rate and strategy performance
+- Market insights and recommendations
+
+Use sub-agents to analyze multiple markets in parallel during high-volume periods.
+
+Never use real money. This is paper trading only.
+```
+
+4. Iterate on strategies based on performance. Adjust thresholds, add new strategies, backtest historical data.
+
+## Related Links
+
+- [Polymarket API](https://docs.polymarket.com/)
+- [Paper Trading Best Practices](https://www.investopedia.com/articles/trading/11/paper-trading.asp)

--- a/usecases/project-state-management.md
+++ b/usecases/project-state-management.md
@@ -1,0 +1,97 @@
+# Project State Management System: Event-Driven Alternative to Kanban
+
+Traditional Kanban boards are static and require manual updates. You forget to move cards, lose context between sessions, and can't track the "why" behind state changes. Projects drift without clear visibility.
+
+This workflow replaces Kanban with an event-driven system that tracks project state automatically:
+
+• Stores project state in a database with full history
+• Captures context: decisions, blockers, next steps, key insights
+• Event-driven updates: "Just finished X, blocked on Y" → automatic state transition
+• Natural language queries: "What's the status of [project]?", "Why did we pivot on [feature]?"
+• Daily standup summaries: What happened yesterday, what's planned today, what's blocked
+• Git integration: links commits to project events for traceability
+
+## Pain Point
+
+Kanban boards become stale. You waste time updating cards instead of doing work. Context gets lost—three months later, you can't remember why you made a key decision. There's no automatic link between code changes and project progress.
+
+## What It Does
+
+Instead of dragging cards, you chat with your assistant: "Finished the auth flow, starting on the dashboard." The system logs the event, updates project state, and preserves context. When you ask "Where are we on the dashboard?" it gives you the full story: what's done, what's next, what's blocking you, and why.
+
+Git commits are automatically scanned and linked to projects. Your daily standup summary writes itself.
+
+## Skills Needed
+
+- `postgres` or SQLite for project state database
+- `github` (gh CLI) for commit tracking
+- Discord or Telegram for updates and queries
+- Cron jobs for daily summaries
+- Sub-agents for parallel project analysis
+
+## How to Set it Up
+
+1. Set up a project state database:
+```sql
+CREATE TABLE projects (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE,
+  status TEXT, -- e.g., "active", "blocked", "completed"
+  current_phase TEXT,
+  last_update TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE events (
+  id SERIAL PRIMARY KEY,
+  project_id INTEGER REFERENCES projects(id),
+  event_type TEXT, -- e.g., "progress", "blocker", "decision", "pivot"
+  description TEXT,
+  context TEXT,
+  timestamp TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE blockers (
+  id SERIAL PRIMARY KEY,
+  project_id INTEGER REFERENCES projects(id),
+  blocker_text TEXT,
+  status TEXT DEFAULT 'open', -- "open", "resolved"
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ
+);
+```
+
+2. Create a Discord channel for project updates (e.g., #project-state).
+
+3. Prompt OpenClaw:
+```text
+You are my project state manager. Instead of Kanban, I'll tell you what I'm working on conversationally.
+
+When I say things like:
+- "Finished [task]" → log a "progress" event, update project state
+- "Blocked on [issue]" → create a blocker entry, update project status to "blocked"
+- "Starting [new task]" → log a "progress" event, update current phase
+- "Decided to [decision]" → log a "decision" event with full context
+- "Pivoting to [new approach]" → log a "pivot" event with reasoning
+
+When I ask:
+- "What's the status of [project]?" → fetch latest events, blockers, and current phase
+- "Why did we decide [X]?" → search events for decision context
+- "What's blocking us?" → list all open blockers across projects
+
+Every morning at 9 AM, run a cron job to:
+1. Scan git commits from the past 24 hours (via gh CLI)
+2. Link commits to projects based on branch names or commit messages
+3. Post a daily standup summary to Discord #project-state:
+   - What happened yesterday (events + commits)
+   - What's planned today (based on current phase and recent conversations)
+   - What's blocked (open blockers)
+
+When I'm planning a sprint, spawn a sub-agent to analyze each project's state and suggest priorities.
+```
+
+4. Integrate with your workflow: Just talk to your assistant naturally about what you're doing. The system captures everything.
+
+## Related Links
+
+- [Event Sourcing Pattern](https://martinfowler.com/eaaDev/EventSourcing.html)
+- [Why Kanban Fails for Solo Developers](https://blog.nuclino.com/why-kanban-doesnt-work-for-me)


### PR DESCRIPTION
Contributing 3 use cases from production OpenClaw setup:
1. Polymarket Autopilot - Paper trading automation
2. Project State Management - Event-driven Kanban alternative
3. Dynamic Dashboard - Parallel sub-agent monitoring

All running in production.