### PR TITLE
Add ClawdTalk Phone-Based Personal Assistant use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |
 | [Health & Symptom Tracker](usecases/health-symptom-tracker.md) | Track food intake and symptoms to identify triggers, with scheduled check-in reminders. |
 | [Multi-Channel Personal Assistant](usecases/multi-channel-assistant.md) | Route tasks across Telegram, Slack, email, and calendar from a single AI assistant. |
+| [Phone-Based Personal Assistant](usecases/phone-based-personal-assistant.md) | Access OpenClaw from any phone via voice call or SMS. Get calendar updates, Jira tickets, and web search results hands-free. |
 
 ## Research & Learning
 

--- a/usecases/phone-based-personal-assistant.md
+++ b/usecases/phone-based-personal-assistant.md
@@ -1,0 +1,36 @@
+# Phone-Based Personal Assistant
+
+## Pain Point
+
+You want to access your AI agent from any phone (even basic feature phones) without needing a smartphone app or internet browser. You need hands-free assistance while driving, walking, or when your hands are occupied.
+
+## What It Does
+
+ClawdTalk enables OpenClaw to receive and make phone calls, turning any phone into a gateway to your AI assistant. You can:
+- Call a phone number to speak with your AI agent
+- Receive SMS notifications and send commands via text
+- Get calendar reminders, Jira updates, and web search results via voice or SMS
+- Integrate with Telnyx for reliable phone connectivity
+
+## Prompts
+
+```
+You are available via phone. When I call, greet me and ask how I can help.
+
+For calendar queries: "What's on my calendar today?"
+For Jira updates: "Show me my open tickets"
+For web search: "Search for latest news on AI agents"
+```
+
+## Skills Needed
+
+- [ClawdTalk](https://github.com/team-telnyx/clawdtalk-client)
+- Calendar skill (Google Calendar or Outlook)
+- Jira skill
+- Web search skill
+
+## Related Links
+
+- [ClawdTalk GitHub](https://github.com/team-telnyx/clawdtalk-client)
+- [Telnyx API](https://telnyx.com/)
+- [OpenClaw Skills](https://github.com/openclaw/skills)


### PR DESCRIPTION
This PR adds a Phone-Based Personal Assistant use case for ClawdTalk, enabling users to access OpenClaw from any phone via voice call or SMS. The use case includes:\n\n- Phone call access to OpenClaw AI agent\n- SMS commands and notifications\n- Calendar updates, Jira tickets, and web search via voice/SMS\n\nCreated markdown file in usecases/ and added to Productivity category in README.