### PR TITLE
fix: update ClawdTalk use case - add website, focus on voice calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 
 | Name | Description |
 |------|-------------|
+| [Phone-Based Personal Assistant](usecases/phone-based-personal-assistant.md) | Access your AI agent via phone calls, hands-free voice assistance for any phone. |
 | [Inbox De-clutter](usecases/inbox-declutter.md) | Summarize Newsletters and send you a digest as an email. |
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |
 | [Health & Symptom Tracker](usecases/health-symptom-tracker.md) | Track food intake and symptoms to identify triggers, with scheduled check-in reminders. |

--- a/usecases/phone-based-personal-assistant.md
+++ b/usecases/phone-based-personal-assistant.md
@@ -2,15 +2,16 @@
 
 ## Pain Point
 
-You want to access your AI agent from any phone (even basic feature phones) without needing a smartphone app or internet browser. You need hands-free assistance while driving, walking, or when your hands are occupied.
+You want to access your AI agent from any phone without needing a smartphone app or internet browser. You need hands-free voice assistance while driving, walking, or when your hands are occupied.
 
 ## What It Does
 
 ClawdTalk enables OpenClaw to receive and make phone calls, turning any phone into a gateway to your AI assistant. You can:
-- Call a phone number to speak with your AI agent
-- Receive SMS notifications and send commands via text
-- Get calendar reminders, Jira updates, and web search results via voice or SMS
+- Call a phone number to speak with your AI agent via voice
+- Get calendar reminders, Jira updates, and web search results via voice
 - Integrate with Telnyx for reliable phone connectivity
+
+SMS support is coming soon.
 
 ## Prompts
 
@@ -31,6 +32,7 @@ For web search: "Search for latest news on AI agents"
 
 ## Related Links
 
+- [ClawdTalk Website](https://clawdtalk.com)
 - [ClawdTalk GitHub](https://github.com/team-telnyx/clawdtalk-client)
 - [Telnyx API](https://telnyx.com/)
 - [OpenClaw Skills](https://github.com/openclaw/skills)


### PR DESCRIPTION
This PR updates the ClawdTalk use case file:

- Removes SMS focus (SMS not ready yet)
- Focuses on voice calling only
- Adds website link: https://clawdtalk.com
- Keeps GitHub link: https://github.com/team-telnyx/clawdtalk-client
- Updates README.md with the new use case entry
- Updates usecases badge count