### PR TITLE
Add use case: Browser-Based Server Builder & Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Daily YouTube Digest](usecases/daily-youtube-digest.md) | Get daily summaries of new videos from your favorite channels — never miss content from creators you follow. |
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
 
+## Configuration & Setup
+
+| Name | Description |
+|------|-------------|
+| [Browser-Based Server Builder](usecases/browser-server-builder.md) | Build, test, and share OpenClaw server configurations entirely in the browser — visual builder, in-browser sandbox with free AI models, server library. No install required. ([vibeclaw.dev](https://vibeclaw.dev)) |
+
 ## Creative & Building
 
 | Name | Description |

--- a/usecases/browser-server-builder.md
+++ b/usecases/browser-server-builder.md
@@ -1,0 +1,72 @@
+# Browser-Based Server Builder & Sandbox
+
+Build, test, and share OpenClaw server configurations entirely in your browser — no install, no terminal, no server required.
+
+## What It Does
+
+- Visual 6-step server builder (name, model, agents, skills, channels, review) that generates a complete OpenClaw config
+- Boots a full OpenClaw sandbox instance **in the browser** with free AI models — you can chat with your agent immediately
+- Server library to save, duplicate, export, and import configurations
+- Flavour system lets you switch between pre-built server personalities (DevOps, Creative Studio, Security Auditor, etc.)
+- Share configs as JSON files — others can import and boot them instantly
+
+## Pain Point
+
+Setting up OpenClaw for the first time means installing Node.js, running CLI commands, editing YAML configs, and figuring out which models and skills to use. For non-technical users or people who just want to try different agent setups quickly, this is too much friction. You want to experiment with different configurations, test them live, and save the ones that work — all without touching a terminal.
+
+## Skills You Need
+
+None. VibeClaw runs entirely in your browser at [vibeclaw.dev](https://vibeclaw.dev). No OpenClaw installation required.
+
+## How to Set It Up
+
+### Step 1: Open VibeClaw
+
+Go to [vibeclaw.dev](https://vibeclaw.dev) and click **BOOT YOUR SERVER NOW**.
+
+The sandbox boots a full OpenClaw instance in your browser in under 3 seconds. You can start chatting with the default agent immediately using free AI models (Solar Pro 3, DeepSeek R1, Llama 3.1, etc.).
+
+### Step 2: Try Different Flavours
+
+Use the flavour dropdown on the homepage to switch between pre-configured server personalities:
+
+- **DevOps SRE** — Infrastructure monitoring, incident response
+- **Creative Studio** — Content generation, brainstorming
+- **Security Auditor** — Vulnerability scanning, compliance checks
+- **Personal Assistant** — Calendar, email, task management
+
+Each flavour comes with pre-configured agents, skills, and system prompts.
+
+### Step 3: Build a Custom Server (ClawForge)
+
+Click **Forge** in the nav to open the visual builder:
+
+1. **Name & describe** your server
+2. **Choose a model** (free models available, Pro models coming soon)
+3. **Configure agents** with custom system prompts
+4. **Select skills** from the available library
+5. **Set up channels** (Telegram, Discord, WhatsApp, etc.)
+6. **Review & save** — configs auto-save as you build
+
+### Step 4: Manage Your Library
+
+Click **My Servers** to see all your saved configurations. From here you can:
+
+- **Boot** any config directly in the sandbox
+- **Duplicate** a config to create variations
+- **Export** as JSON to share with others
+- **Import** configs from files or community shares
+- **Delete** configs you no longer need
+
+## Tips
+
+- **Auto-save is on** — your work in the Forge saves automatically every 500ms, so you never lose progress
+- **Export before experimenting** — duplicate a working config before making big changes
+- **Free models are surprisingly capable** — Solar Pro 3 and DeepSeek R1 handle most agent tasks well
+- **Share configs with your team** — export JSON files and have others import them to get identical setups
+
+## Links
+
+- **Live site:** [vibeclaw.dev](https://vibeclaw.dev)
+- **Source:** [github.com/jasonkneen/vibeclaw](https://github.com/jasonkneen/vibeclaw)
+- **Forge builder:** [vibeclaw.dev/forge](https://vibeclaw.dev/forge)


### PR DESCRIPTION
Adds a new use case for building and testing OpenClaw server configurations entirely in the browser using [VibeClaw](https://vibeclaw.dev).

**Includes:**
- Full use case writeup in `usecases/browser-server-builder.md` (follows existing format)
- New "Configuration & Setup" category in README table
- Step-by-step guide covering sandbox boot, flavours, ClawForge builder, and library management

**Key differentiator:** Runs a full OpenClaw instance in the browser with free AI models — zero install, zero server, zero friction.

- **Live:** https://vibeclaw.dev
- **Source:** https://github.com/jasonkneen/vibeclaw