### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
 
+## Security & Guardrails
+
+| Name | Description |
+|------|-------------|
+| [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) | Pre-action authorization for OpenClaw; every tool call checked before it runs. Allowlist + 40+ blocked patterns, local or API. Setup: `npx @aporthq/agent-guardrails` |
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adds [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) — pre-action authorization for OpenClaw and compatible agent frameworks. Policy runs in the platform `before_tool_call` hook; 40+ blocked patterns, allowlist, local or API. Setup: `npx @aporthq/agent-guardrails`.