### PR TITLE
Add Changelog & Version Update Monitor use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Custom Morning Brief](usecases/custom-morning-brief.md) | Get a fully customized daily briefing — news, tasks, content drafts, and AI-recommended actions — texted to you every morning. |
 | [Second Brain](usecases/second-brain.md) | Text anything to your bot to remember it, then search through all your memories in a custom Next.js dashboard. |
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
+| [Changelog & Version Update Monitor](usecases/changelog-version-monitor.md) | Track version updates of tools, apps, and services — never miss new features, security patches, or breaking changes. |
 
 ## Research & Learning
 

--- a/usecases/changelog-version-monitor.md
+++ b/usecases/changelog-version-monitor.md
@@ -1,0 +1,55 @@
+# Changelog & Version Update Monitor
+
+Track version updates of tools, apps, and services you depend on — never miss new features, security patches, or breaking changes again.
+
+We all rely on dozens of software tools across work and life: developer frameworks, productivity apps, SaaS services, mobile apps. But staying updated means manually checking websites, reading newsletters, or discovering changes only when something breaks. Important security patches and useful features slip through the cracks for months.
+
+## What It Does
+
+- Monitors version updates from multiple sources:
+  - GitHub releases for open-source tools
+  - Package managers (npm, PyPI, Homebrew)
+  - Official changelogs and RSS feeds
+  - App Store or marketplace updates
+- Remembers last-known versions locally to avoid duplicate notifications
+- Only alerts when there's an actual version change, not on every check
+- Delivers clean summaries with version diff, release date, and key changes
+
+## Skills you Need
+
+- Custom monitoring script that:
+  - Fetches latest versions from various APIs or web sources
+  - Stores state in a local file (JSON, SQLite, etc.)
+  - Formats notifications with version comparison and highlights
+
+## How to Set it Up
+
+1. Create a monitoring script for your specific sources (GitHub API, RSS parser, etc.)
+2. Add tools/services to track with their update sources
+3. Set up a daily or weekly cron job:
+
+```text
+Run version monitor every morning at 9am. Notify me only when there are actual updates.
+```
+
+## Prompts
+
+**Check updates immediately:**
+```text
+Run version monitor now and show me any updates across all tracked tools.
+```
+
+**Add a new tool to track:**
+```text
+Add VS Code to my version monitor. Check the official site for updates.
+```
+
+**View tracked versions:**
+```text
+Show me all the versions I'm currently tracking and when they were last checked.
+```
+
+## Related Links
+
+- [GitHub API - Releases](https://docs.github.com/en/rest/releases/releases)
+- [RSS Feed Parser libraries](https://github.com/topics/rss-parser)


### PR DESCRIPTION
Track version updates of tools, apps, and services — never miss new features, security patches, or breaking changes again.

## What it does
- Monitors version updates from GitHub releases, package managers, RSS feeds, and app stores
- Remembers last-known versions to avoid duplicate notifications
- Only alerts on actual version changes
- Delivers clean summaries with version diff and key changes

## Category
Productivity

This use case has been tested and verified working.