### PR TITLE
feat: expand tech-news-digest with Reddit layer, dual Twitter backend, and PDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Daily Reddit Digest](usecases/daily-reddit-digest.md) | Summarize a curated digest of your favourite subreddits, based on your preferences. |
 | [Daily YouTube Digest](usecases/daily-youtube-digest.md) | Get daily summaries of new videos from your favorite channels — never miss content from creators you follow. |
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
-| [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | Automatically aggregate and deliver quality-scored tech news from 109+ sources (RSS, Twitter/X, GitHub, web search) via natural language. |
+| [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | One-command daily tech digest — 150+ built-in sources across 6 layers (RSS, Twitter/X, GitHub, GitHub Trending, Reddit, web search) with quality scoring, article enrichment, and multi-format delivery. Works out of the box, fully customizable with your own sources. |
 | [X/Twitter Automation](usecases/x-twitter-automation.md) | Post tweets, reply, like, retweet, follow, DM, search, extract data, run giveaways, and monitor accounts — all from chat via the TweetClaw plugin. |
 
 ## Creative & Building

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Daily Reddit Digest](usecases/daily-reddit-digest.md) | Summarize a curated digest of your favourite subreddits, based on your preferences. |
 | [Daily YouTube Digest](usecases/daily-youtube-digest.md) | Get daily summaries of new videos from your favorite channels — never miss content from creators you follow. |
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
-| [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | One-command daily tech digest — 150+ built-in sources across 6 layers (RSS, Twitter/X, GitHub, GitHub Trending, Reddit, web search) with quality scoring, article enrichment, and multi-format delivery. Works out of the box, fully customizable with your own sources. |
+| [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | One-command daily tech digest — 150+ built-in sources across 6 layers (RSS, Twitter/X, GitHub Releases, GitHub Trending, Reddit, web search) with quality scoring, article enrichment, and multi-format delivery. Works out of the box, fully customizable with your own sources. |
 | [X/Twitter Automation](usecases/x-twitter-automation.md) | Post tweets, reply, like, retweet, follow, DM, search, extract data, run giveaways, and monitor accounts — all from chat via the TweetClaw plugin. |
 
 ## Creative & Building

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,7 +34,7 @@
 | [每日 Reddit 摘要](usecases/daily-reddit-digest.md) | 根据你的偏好，总结你喜爱的 subreddit 的精选摘要。 |
 | [每日 YouTube 摘要](usecases/daily-youtube-digest.md) | 获取你关注频道的每日新视频摘要 —— 不错过你关注创作者的任何内容。 |
 | [X 账号分析](usecases/x-account-analysis.md) | 获取你的 X 账号的定性分析。|
-| [多源科技新闻摘要](usecases/multi-source-tech-news-digest.md) | 自动聚合和分发来自 109+ 来源（RSS、Twitter/X、GitHub、网页搜索）的质量评分科技新闻。 |
+| [多源科技新闻摘要](usecases/multi-source-tech-news-digest.md) | 一句话安装的科技日报 — 内置 150+ 数据源，6 层采集（RSS、Twitter/X、GitHub、GitHub Trending、Reddit、Web 搜索），质量评分 + 文章全文增强 + 多格式推送。开箱即用，支持自定义扩展数据源。 |
 
 ## 创意与构建
 

--- a/usecases/multi-source-tech-news-digest.md
+++ b/usecases/multi-source-tech-news-digest.md
@@ -1,23 +1,27 @@
 # Multi-Source Tech News Digest
 
-Automatically aggregate, score, and deliver tech news from 109+ sources across RSS, Twitter/X, GitHub releases, and web search — all managed through natural language.
+Automatically aggregate, score, and deliver tech news from 150+ sources across 6 data layers — all managed through natural language.
 
 ## Pain Point
 
-Staying updated across AI, open-source, and frontier tech requires checking dozens of RSS feeds, Twitter accounts, GitHub repos, and news sites daily. Manual curation is time-consuming, and most existing tools either lack quality filtering or require complex configuration.
+Staying updated across AI, open-source, and frontier tech requires checking dozens of RSS feeds, Twitter accounts, GitHub repos, Reddit threads, and news sites daily. Manual curation is time-consuming, and most existing tools either lack quality filtering or require complex configuration.
 
 ## What It Does
 
-A four-layer data pipeline that runs on a schedule:
+A six-source pipeline that runs on a schedule (~30s):
 
-1. **RSS Feeds** (46 sources) — OpenAI, Hacker News, MIT Tech Review, etc.
-2. **Twitter/X KOLs** (44 accounts) — @karpathy, @sama, @VitalikButerin, etc.
-3. **GitHub Releases** (19 repos) — vLLM, LangChain, Ollama, Dify, etc.
-4. **Web Search** (4 topic searches) — via Brave Search API
+1. **RSS Feeds** (62 sources) — OpenAI, Hacker News, MIT Tech Review, indie tech blogs, etc.
+2. **Twitter/X KOLs** (48 accounts) — @karpathy, @sama, @VitalikButerin, etc. (dual backend: official X API v2 + twitterapi.io)
+3. **GitHub Releases** (28 repos) — vLLM, LangChain, Ollama, Foundry, etc.
+4. **GitHub Trending** — Daily trending repos via Search API across 4 topics
+5. **Reddit** (13 subreddits) — r/MachineLearning, r/LocalLLaMA, r/ChatGPT, etc.
+6. **Web Search** (Tavily or Brave) — 4 topic searches with API key rotation
 
-All articles are merged, deduplicated by title similarity, and quality-scored (priority source +3, multi-source +5, recency +2, engagement +1). The final digest is delivered to Discord, email, or Telegram.
+All articles are merged, URL-deduplicated, and quality-scored (priority source +3, multi-source cross-ref +5, recency +2, engagement +1, Reddit score bonus +1/+3/+5). High-scoring articles can optionally be enriched with full text via Cloudflare Markdown for Agents.
 
-The framework is fully customizable — add your own RSS feeds, Twitter handles, GitHub repos, or search queries in 30 seconds.
+Output sections: 🧠 LLM, 🤖 AI Agent, 🔬 Frontier Tech, 📢 KOL Updates, 📦 GitHub Releases, 🐙 GitHub Trending, 📝 Blog Picks — delivered to Discord, email (with PDF attachment), or Telegram.
+
+The framework is fully customizable — add your own RSS feeds, Twitter handles, GitHub repos, subreddits, or search queries in seconds.
 
 ## Prompts
 
@@ -32,6 +36,7 @@ Add these to my tech digest sources:
 - RSS: https://my-company-blog.com/feed
 - Twitter: @myFavResearcher
 - GitHub: my-org/my-framework
+- Reddit: r/YourSubreddit
 ```
 
 **Generate on demand:**
@@ -39,16 +44,44 @@ Add these to my tech digest sources:
 Generate a tech digest for the past 24 hours and send it here.
 ```
 
+**Weekly digest with enrichment:**
+```text
+Generate a weekly tech digest with full-text article enrichment enabled.
+```
+
 ## Skills Needed
 
 - [tech-news-digest](https://clawhub.ai/skills/tech-news-digest) — Install via `clawhub install tech-news-digest`
-- [gog](https://clawhub.ai/skills/gog) (optional) — For email delivery via Gmail
 
 ## Environment Variables (Optional)
 
-- `X_BEARER_TOKEN` — Twitter/X API bearer token for KOL monitoring
-- `BRAVE_API_KEY` — Brave Search API key for web search layer
+All variables are optional — the pipeline works out of the box with whatever sources are available.
+
+- `TWITTER_API_BACKEND` — Backend selection: `auto` (default), `official` (X API v2), or `twitterapiio`
+- `X_BEARER_TOKEN` — Twitter/X API v2 bearer token (required for `official` backend)
+- `TWITTERAPI_IO_KEY` — twitterapi.io API key (required for `twitterapiio` backend)
+- `BRAVE_API_KEY` / `BRAVE_API_KEYS` — Brave Search API key(s), comma-separated for rotation
+- `TAVILY_API_KEY` — Tavily Search API key (preferred over Brave when available)
+- `WEB_SEARCH_BACKEND` — `auto` (default) / `brave` / `tavily`
 - `GITHUB_TOKEN` — GitHub token for higher API rate limits
+
+## Customization
+
+Works out of the box with 150+ sources. Override defaults by placing config overlays in your workspace:
+
+```bash
+cp config/defaults/sources.json workspace/config/tech-news-digest-sources.json
+```
+
+Your overlay **merges** with defaults — only include what you want to change:
+- Match an `id` to override or disable (`"enabled": false`) a built-in source
+- Use a new `id` to add your own sources
+
+## Output Formats
+
+- **Discord** — Bullet list with emoji headers, link suppression, mobile-optimized
+- **Email** — HTML body with PDF attachment (Chinese typography via Noto Sans CJK)
+- **PDF** — Styled A4 with page headers/footers, blue accent theme
 
 ## Related Links
 

--- a/usecases/multi-source-tech-news-digest.md
+++ b/usecases/multi-source-tech-news-digest.md
@@ -17,7 +17,7 @@ A six-source pipeline that runs on a schedule (~30s):
 5. **Reddit** (13 subreddits) — r/MachineLearning, r/LocalLLaMA, r/ChatGPT, etc.
 6. **Web Search** (Tavily or Brave) — 4 topic searches with API key rotation
 
-All articles are merged, URL-deduplicated, and quality-scored (priority source +3, multi-source cross-ref +5, recency +2, engagement +1, Reddit score bonus +1/+3/+5). High-scoring articles can optionally be enriched with full text via Cloudflare Markdown for Agents.
+All articles are merged, URL-deduplicated, and quality-scored (priority source +3, multi-source cross-ref +5, recency +2, engagement +1, Reddit score bonus +1/+3/+5). High-scoring articles can optionally be enriched with full text via [Cloudflare Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/).
 
 Output sections: 🧠 LLM, 🤖 AI Agent, 🔬 Frontier Tech, 📢 KOL Updates, 📦 GitHub Releases, 🐙 GitHub Trending, 📝 Blog Picks — delivered to Discord, email (with PDF attachment), or Telegram.
 
@@ -60,7 +60,7 @@ All variables are optional — the pipeline works out of the box with whatever s
 - `TWITTER_API_BACKEND` — Backend selection: `auto` (default), `official` (X API v2), or `twitterapiio`
 - `X_BEARER_TOKEN` — Twitter/X API v2 bearer token (required for `official` backend)
 - `TWITTERAPI_IO_KEY` — twitterapi.io API key (required for `twitterapiio` backend)
-- `BRAVE_API_KEY` / `BRAVE_API_KEYS` — Brave Search API key(s), comma-separated for rotation
+- `BRAVE_API_KEY` / `BRAVE_API_KEYS` — Brave Search API key(s); use `BRAVE_API_KEYS` (comma-separated) for automatic rotation, or `BRAVE_API_KEY` for a single key
 - `TAVILY_API_KEY` — Tavily Search API key (preferred over Brave when available)
 - `WEB_SEARCH_BACKEND` — `auto` (default) / `brave` / `tavily`
 - `GITHUB_TOKEN` — GitHub token for higher API rate limits


### PR DESCRIPTION
Update tech-news-digest: 138 sources, Reddit layer, dual Twitter backend, PDF output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded "Multi-Source Tech News Digest": now 150+ sources across six collection layers (RSS, Twitter/X, GitHub Releases, GitHub Trending, Reddit, web search); quality scoring, URL-based deduplication, optional full-article enrichment, ~30s cadence, and weekly digest enrichment.
  * Multi-format delivery: Discord, Email (PDF), Telegram.
  * New customization: config overlay merge for adding/overriding/disabling sources; updated Chinese README and usage docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->