### PR TITLE
feat: add 3 new use cases (meeting notes, habit tracker, podcast pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-30-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-33-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 </div>
 
@@ -39,6 +39,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [YouTube Content Pipeline](usecases/youtube-content-pipeline.md) | Automate video idea scouting, research, and tracking for a YouTube channel. |
 | [Multi-Agent Content Factory](usecases/content-factory.md) | Run a multi-agent content pipeline in Discord — research, writing, and thumbnail agents working in dedicated channels. |
 | [Autonomous Game Dev Pipeline](usecases/autonomous-game-dev-pipeline.md) | Full lifecycle management of educational game development: from backlog selection to implementation, registration, documentation, and git commit. Enforces "Bugs First" policy. |
+| [Podcast Production Pipeline](usecases/podcast-production-pipeline.md) | Automate the full podcast workflow — guest research, episode outlines, show notes, and social media promo — from topic to publish-ready assets. |
 
 ## Infrastructure & DevOps
 
@@ -65,6 +66,8 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Family Calendar & Household Assistant](usecases/family-calendar-household-assistant.md) | Aggregate all family calendars into a morning briefing, monitor messages for appointments, and manage household inventory. |
 | [Multi-Agent Specialized Team](usecases/multi-agent-team.md) | Run multiple specialized agents (strategy, dev, marketing, business) as a coordinated team via a single Telegram chat. |
 | [Custom Morning Brief](usecases/custom-morning-brief.md) | Get a fully customized daily briefing — news, tasks, content drafts, and AI-recommended actions — texted to you every morning. |
+| [Automated Meeting Notes & Action Items](usecases/meeting-notes-action-items.md) | Turn meeting transcripts into structured summaries and automatically create tasks in Jira, Linear, or Todoist — assigned to the right person. |
+| [Habit Tracker & Accountability Coach](usecases/habit-tracker-accountability-coach.md) | Proactive daily check-ins via Telegram or SMS that track habits, maintain streaks, and adapt their tone based on your progress. |
 | [Second Brain](usecases/second-brain.md) | Text anything to your bot to remember it, then search through all your memories in a custom Next.js dashboard. |
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
 

--- a/usecases/habit-tracker-accountability-coach.md
+++ b/usecases/habit-tracker-accountability-coach.md
@@ -1,0 +1,84 @@
+# Habit Tracker & Accountability Coach
+
+You've tried every habit tracker app out there. They all work for a week, then you stop opening them. The problem isn't the app — it's that tracking habits is passive. What if your agent actively reached out to you, asked how your day went, and adapted its approach based on whether you're on a streak or falling off?
+
+This use case turns OpenClaw into a proactive accountability partner that checks in with you daily via Telegram or SMS.
+
+## Pain Point
+
+Habit apps rely on you remembering to open them. Push notifications are easy to ignore. What actually works for behavior change is **active accountability** — someone (or something) that asks you directly, celebrates your wins, and nudges you when you slip. This agent does exactly that, without the awkwardness of bugging a friend.
+
+## What It Does
+
+- **Daily check-ins** via Telegram or SMS at times you choose (e.g., 7 AM for morning routine, 9 PM for end-of-day review)
+- **Tracks habits** you define — exercise, reading, meditation, water intake, coding, whatever matters to you
+- **Streak tracking** — knows your current streak for each habit and references it in messages
+- **Adaptive nudges** — adjusts tone based on your performance (encouraging when you're consistent, gently persistent when you miss days)
+- **Weekly reports** — summarizes your week with completion rates, longest streaks, and patterns (e.g., "You tend to skip workouts on Wednesdays")
+
+## Skills You Need
+
+- Telegram or SMS integration (Twilio for SMS, or Telegram Bot API)
+- Scheduling / cron for timed check-ins
+- File system or database access for storing habit data
+- Optional: Google Sheets integration for a visual habit dashboard
+
+## How to Set It Up
+
+1. Define your habits and check-in schedule:
+```text
+I want you to be my accountability coach. Track these daily habits for me:
+
+1. Morning workout (check in at 7:30 AM)
+2. Read for 30 minutes (check in at 8:00 PM)
+3. No social media before noon (check in at 12:30 PM)
+4. Drink 8 glasses of water (check in at 6:00 PM)
+
+Send me a Telegram message at each check-in time asking if I completed
+the habit. Keep track of my streaks in a local file.
+```
+
+2. Set up the tracking and tone:
+```text
+When I confirm a habit, respond with a short encouraging message and
+mention my current streak. Example: "Day 12 of morning workouts. Solid."
+
+When I miss a habit, don't guilt-trip me. Just acknowledge it and remind
+me why I started. If I miss 3 days in a row, send a longer motivational
+message and ask if I want to adjust the goal.
+
+If I don't respond to a check-in within 2 hours, send one follow-up.
+Don't spam me after that.
+```
+
+3. Add weekly reports:
+```text
+Every Sunday at 10 AM, send me a weekly summary:
+- Completion rate for each habit
+- Current streaks
+- Best day and worst day
+- One pattern you noticed (e.g., "You always skip reading on Fridays")
+- One suggestion for next week
+
+Store all data in ~/habits/log.json so I can review history anytime.
+```
+
+4. Optional — visual dashboard via Google Sheets:
+```text
+At the end of each day, update a Google Sheet with today's habit data.
+Columns: Date, Workout, Reading, No Social Media, Water, Notes.
+Mark completed habits with ✓ and missed with ✗.
+```
+
+## Key Insights
+
+- The **adaptive tone** is what makes this different from a cron job. A static reminder gets ignored. A message that says "Day 15, don't break it now" actually motivates.
+- Keep the number of tracked habits small (3-5). Tracking too many leads to check-in fatigue and you'll start ignoring the messages.
+- The weekly pattern analysis is surprisingly useful — you'll discover things like "I never exercise on days I have early meetings" and can plan around it.
+- Pairs well with the [Health & Symptom Tracker](health-symptom-tracker.md) if you want to correlate habits with how you feel.
+
+## Related Links
+
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+- [Twilio SMS API](https://www.twilio.com/docs/sms)
+- [Google Sheets API](https://developers.google.com/sheets/api)

--- a/usecases/meeting-notes-action-items.md
+++ b/usecases/meeting-notes-action-items.md
@@ -1,0 +1,82 @@
+# Automated Meeting Notes & Action Items
+
+You just finished a 45-minute team call. Now you need to write up the summary, pull out action items, and distribute them to Jira, Linear, or Todoist — manually. By the time you're done, the next meeting is starting. What if your agent handled all of that the moment the transcript lands?
+
+This use case turns any meeting transcript into structured notes and automatically creates tasks in your project management tool.
+
+## Pain Point
+
+Meeting notes are tedious but critical. Most people either skip them (and lose context) or spend 20+ minutes writing them up. Action items get forgotten because they live in someone's head or buried in a chat thread. This agent eliminates the gap between "we discussed it" and "it's tracked and assigned."
+
+## What It Does
+
+- **Watches** for new meeting transcripts (via Otter.ai export, Google Meet transcript, Zoom recording summary, or a simple paste into chat)
+- **Extracts** key decisions, discussion topics, and action items with owners and deadlines
+- **Creates tasks** in Jira, Linear, Todoist, or Notion — assigned to the right person with context from the meeting
+- **Posts a summary** to Slack or Discord so the whole team has a record
+- **Follows up** — optionally pings assignees before deadlines via scheduled reminders
+
+## Skills You Need
+
+- Jira, Linear, Todoist, or Notion integration (for task creation)
+- Slack or Discord integration (for posting summaries)
+- File system access (for reading transcript files)
+- Scheduling / cron (for follow-up reminders)
+- Optional: Otter.ai, Fireflies.ai, or Google Meet API for automatic transcript retrieval
+
+## How to Set It Up
+
+1. Choose your transcript source. The simplest approach is pasting the transcript directly into chat. For automation, set up a folder watch or API integration.
+
+2. Prompt OpenClaw:
+```text
+I just finished a meeting. Here's the transcript:
+
+[paste transcript or point to file]
+
+Please:
+1. Write a concise summary (max 5 bullet points) covering key decisions and topics.
+2. Extract ALL action items. For each one, identify:
+   - What needs to be done
+   - Who is responsible (match names to my team)
+   - Deadline (if mentioned, otherwise mark as "TBD")
+3. Create a Jira ticket for each action item, assigned to the right person.
+4. Post the full summary to #meeting-notes in Slack.
+```
+
+3. For fully automated pipeline (transcript folder watch):
+```text
+Set up a recurring task: every 30 minutes, check ~/meeting-transcripts/ for
+new .txt or .vtt files. When you find one:
+
+1. Parse the transcript into a structured summary with action items.
+2. Create tasks in Linear for each action item.
+3. Post the summary to #team-updates in Slack.
+4. Move the processed file to ~/meeting-transcripts/processed/.
+
+For each action item with a deadline, set a reminder to ping the assignee
+in Slack one day before it's due.
+```
+
+4. Customize the output format:
+```text
+When writing meeting summaries, always use this structure:
+- **Date & Attendees** at the top
+- **Key Decisions** — numbered list of what was decided
+- **Action Items** — table with columns: Task, Owner, Deadline, Status
+- **Open Questions** — anything unresolved that needs follow-up
+```
+
+## Key Insights
+
+- The real value isn't in the summary — it's in the **automatic task creation**. Meeting notes that don't become tracked tasks are just documentation theater.
+- Pair this with the [Todoist Task Manager](todoist-task-manager.md) use case for full visibility into agent-created tasks.
+- VTT/SRT subtitle files from Zoom or Google Meet work great as input — they include timestamps which help the agent attribute statements to speakers.
+- Start simple (paste transcript, get summary) and automate incrementally. Don't over-engineer the pipeline before validating the output quality.
+
+## Related Links
+
+- [Otter.ai API](https://otter.ai/)
+- [Jira REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/)
+- [Linear API](https://developers.linear.app/)
+- [Slack API](https://api.slack.com/)

--- a/usecases/podcast-production-pipeline.md
+++ b/usecases/podcast-production-pipeline.md
@@ -1,0 +1,93 @@
+# Podcast Production Pipeline
+
+You have a podcast idea, maybe even a backlog of episode topics. But between researching guests, writing outlines, drafting intros, generating show notes, and writing social media posts for promotion — the production overhead kills your momentum. What if you handed off a topic and got back a full production package?
+
+This use case chains agents together to handle the entire podcast production workflow from topic to publish-ready assets.
+
+## Pain Point
+
+Solo podcasters and small teams spend more time on production than on actually recording. Research takes hours, show notes are an afterthought, and social media promotion is the first thing that gets skipped. The creative part — the conversation — is maybe 30% of the total effort. This agent handles the other 70%.
+
+## What It Does
+
+- **Episode Research** — given a topic or guest name, compiles background research, talking points, and suggested questions
+- **Outline & Script** — generates a structured episode outline with intro script, segment transitions, and closing remarks
+- **Show Notes** — after recording, processes the transcript into timestamped show notes with links to everything mentioned
+- **Social Media Kit** — creates promotional posts for X, LinkedIn, and Instagram with episode highlights and pull quotes
+- **Episode Description** — writes SEO-optimized episode descriptions for Spotify, Apple Podcasts, and YouTube
+
+## Skills You Need
+
+- Web search / research skill (for guest research and topic deep-dives)
+- File system access (for reading transcripts and writing output files)
+- Slack, Discord, or Telegram integration (for delivering assets)
+- Optional: `sessions_spawn` for running research and writing agents in parallel
+- Optional: RSS feed skill (for monitoring competitor podcasts)
+
+## How to Set It Up
+
+1. Pre-recording — generate research and outline:
+```text
+I'm recording a podcast episode about [TOPIC]. My guest is [NAME].
+
+Please:
+1. Research the guest — their background, recent work, hot takes, and
+   anything controversial or interesting they've said publicly.
+2. Research the topic — key trends, recent news, common misconceptions,
+   and what the audience likely already knows vs. what would surprise them.
+3. Generate an episode outline:
+   - Cold open hook (1-2 sentences to grab attention)
+   - Intro script (30 seconds, casual tone)
+   - 5-7 interview questions, ordered from easy/rapport-building to deep/provocative
+   - 2-3 "back pocket" questions in case the conversation stalls
+   - Closing segment with call-to-action
+
+Save everything to ~/podcast/episodes/[episode-number]/prep/
+```
+
+2. Post-recording — generate show notes and promo:
+```text
+Here's the transcript for Episode [NUMBER]: [paste or point to file]
+
+Please:
+1. Write timestamped show notes — every major topic shift gets a timestamp
+   and one-line summary. Include links to anything mentioned (tools, books,
+   articles, people).
+2. Write an episode description (max 200 words) optimized for podcast
+   search. Include 3-5 relevant keywords naturally.
+3. Create social media posts:
+   - X/Twitter: 3 tweets — one pull quote, one key insight, one question
+     to spark discussion. Each under 280 chars.
+   - LinkedIn: 1 post, professional tone, 100-150 words.
+   - Instagram caption: 1 post with emoji, casual tone, include relevant hashtags.
+4. Extract a "highlights" list — the 3 most interesting/surprising moments
+   with timestamps.
+
+Save everything to ~/podcast/episodes/[episode-number]/publish/
+```
+
+3. Optional — competitor monitoring:
+```text
+Monitor these podcast RSS feeds daily:
+- [feed URL 1]
+- [feed URL 2]
+
+When a new episode drops that covers a topic relevant to my podcast,
+send me a Telegram message with:
+- Episode title and link
+- One-sentence summary
+- Whether this is something I should respond to or cover from my angle
+```
+
+## Key Insights
+
+- The **pre-recording research** is where most value is. Walking into an interview with deep guest research makes the conversation dramatically better — and that's something you can't fake in post-production.
+- Show notes with timestamps are a huge listener retention tool. Most podcasters skip them because they're tedious. This agent makes them effortless.
+- The social media kit saves the most *recurring* time. You need promo for every single episode, and it's always the same structure — perfect for automation.
+- Pairs well with the [Multi-Agent Content Factory](content-factory.md) if you want to repurpose podcast content into blog posts, newsletters, or video clips.
+
+## Related Links
+
+- [Podcast RSS Feed Spec](https://podcasters.apple.com/support/823-podcast-requirements)
+- [Spotify for Podcasters](https://podcasters.spotify.com/)
+- [Whisper (OpenAI)](https://github.com/openai/whisper) — for local transcript generation


### PR DESCRIPTION
These are my three most-used OpenClaw setups. 
- The Habit Tracker holds me far more accountable than a silent push notification, it's much harder to ignore.
- Meeting Notes has eliminated all my post-call busywork.
- Podcast Pipeline has finally made preparing episodes feel manageable instead of overwhelming.

---

- Add Automated Meeting Notes & Action Items use case
- Add Habit Tracker & Accountability Coach use case
- Add Podcast Production Pipeline use case
- Update use case count badge from 30 to 33