### PR TITLE
Add Beeper Messaging CLI use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Habit Tracker & Accountability Coach](usecases/habit-tracker-accountability-coach.md) | Proactive daily check-ins via Telegram or SMS that track habits, maintain streaks, and adapt their tone based on your progress. |
 | [Second Brain](usecases/second-brain.md) | Text anything to your bot to remember it, then search through all your memories in a custom Next.js dashboard. |
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
+| [Beeper Messaging CLI](usecases/beeper-messaging-cli.md) | Give your agent access to all your messaging apps (iMessage, WhatsApp, Signal, etc.) via Beeper — search, read, send, and manage chats hands-free. |
 
 ## Research & Learning
 

--- a/usecases/beeper-messaging-cli.md
+++ b/usecases/beeper-messaging-cli.md
@@ -1,0 +1,69 @@
+# Beeper Messaging CLI
+
+Your AI agent can't read your messages. If someone texts you a question, you copy it into OpenClaw, get an answer, then paste it back. If you need to find something someone said last week across WhatsApp, iMessage, and Signal, you're searching three apps manually.
+
+Roadrunner (`rr`) gives OpenClaw direct access to all your messaging apps through Beeper Desktop — one CLI for iMessage, WhatsApp, Signal, Slack, and more.
+
+## What It Does
+
+- **Search across all chats**: Find messages across every messaging app in one query
+- **Read and send messages**: Read conversations, send replies, react, and edit — all from your agent
+- **Unread summaries**: Get a roll-up of unread chats across all accounts
+- **Live events**: Stream new messages in real-time via WebSocket
+- **Reminders**: Set and clear chat reminders
+- **Contacts**: Search and resolve contacts across accounts
+- **Attachments**: Download, upload, and stream media
+
+The skill runs in agent-safe mode by default (`--agent` flag), which forces JSON output, read-only access, and requires explicit command allowlisting before any writes.
+
+## Skills You Need
+
+[roadrunner](https://clawhub.ai/johntheyoung/roadrunner) — installs via ClawHub. Requires [Beeper Desktop](https://www.beeper.com/) v4.1.169+ running locally.
+
+## How to Set It Up
+
+1. Install the skill from ClawHub, or manually:
+```bash
+brew install johntheyoung/tap/roadrunner
+```
+
+2. Enable the Beeper Desktop API: **Settings > Developers > Toggle Beeper Desktop API**
+
+3. Create an API token and configure auth:
+```bash
+rr auth set --stdin
+rr doctor
+```
+
+4. Prompt your OpenClaw:
+
+**Morning unread summary:**
+```text
+Every morning at 8am, use rr to check my unread messages across all accounts.
+Summarize what I missed overnight, grouped by chat. Flag anything that looks urgent.
+```
+
+**Search and reply assistant:**
+```text
+When I ask you to find a message, use rr to search across all my chats.
+When I ask you to reply to someone, confirm the chat and message text with me before sending.
+```
+
+**Chat monitor:**
+```text
+Monitor my work Slack channels using rr events. If someone mentions my name or
+asks a question I can answer, draft a response and ask me if I want to send it.
+```
+
+## Key Safety Features
+
+- **Read-only by default** — writes require explicit `--enable-commands` allowlisting
+- **No credential exposure** — auth tokens stay local, never passed through chat
+- **Envelope errors** — structured error responses with hints for safe retries
+- **Stdin for message text** — avoids shell interpolation issues with special characters
+
+## Related Links
+
+- [GitHub: johntheyoung/roadrunner](https://github.com/johntheyoung/roadrunner)
+- [ClawHub Skill](https://clawhub.ai/johntheyoung/roadrunner)
+- [Beeper Desktop](https://www.beeper.com/)


### PR DESCRIPTION
## Summary

Adds a new Productivity use case: **Beeper Messaging CLI** — a ClawHub skill ([roadrunner](https://clawhub.ai/johntheyoung/roadrunner)) that gives OpenClaw access to all your messaging apps through Beeper Desktop.

- **Use case file**: `usecases/beeper-messaging-cli.md`
- **README**: Added row to the Productivity table

### What it covers

- Searching across all messaging apps (iMessage, WhatsApp, Signal, Slack, etc.) in one query
- Reading conversations and sending replies from your agent
- Unread summaries, live event streaming, reminders, contacts, attachments
- Agent safety features (read-only by default, command allowlisting, no credential exposure)
- Setup instructions and prompt examples for common workflows

### Verification

I built and maintain this skill. It's published on ClawHub and has been in daily use since January 2026.