### PR TITLE
Add phone call notifications use case (clawr.ing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-34-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-35-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)
@@ -73,6 +73,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Habit Tracker & Accountability Coach](usecases/habit-tracker-accountability-coach.md) | Proactive daily check-ins via Telegram or SMS that track habits, maintain streaks, and adapt their tone based on your progress. |
 | [Second Brain](usecases/second-brain.md) | Text anything to your bot to remember it, then search through all your memories in a custom Next.js dashboard. |
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
+| [Phone Call Notifications](usecases/phone-call-notifications.md) | Turn your agent's alerts into real phone calls — morning briefings, price drops, urgent emails — with two-way conversation. |
 
 ## Research & Learning
 

--- a/usecases/phone-call-notifications.md
+++ b/usecases/phone-call-notifications.md
@@ -1,0 +1,73 @@
+# Phone Call Notifications
+
+Your agent already monitors things for you — stocks, emails, smart home, calendars — but notifications are easy to ignore. Push notifications pile up. Chat messages get buried. For the stuff that actually matters, you need something you can't swipe away.
+
+This use case gives your agent a phone call as a notification channel. When something is urgent enough, the agent dials your real phone number, tells you what's going on, and you can talk back. Two-way conversation, not a robocall.
+
+## What It Does
+
+- Agent decides something is worth your attention (price alert, urgent email, appointment reminder, anything)
+- Agent calls your phone via [clawr.ing](https://clawr.ing), a managed calling service — no Twilio setup, no API keys to configure
+- You pick up, hear the alert, and can ask follow-up questions in real time
+- Call ends when the conversation is done
+
+The key idea: the agent calls YOU. You don't call the agent. This works with heartbeat checks, cron jobs, or any trigger — the agent evaluates whether something is phone-call-worthy and acts on it.
+
+## Why This Works
+
+OpenClaw agents already have initiative — heartbeat, cron, event triggers. But their output channels are limited to chat platforms you might not be checking. A phone call is the one notification channel that reliably gets your attention, especially when you're away from your desk.
+
+clawr.ing handles the telephony infrastructure. You paste one setup prompt and the agent gains the ability to call. No Twilio account, no phone number provisioning, no webhook configuration. The service covers 100+ countries with real PSTN calls (not VoIP overlays).
+
+## Skills Needed
+
+- [clawr.ing](https://clawhub.ai/marcospgp/clawring) — install by pasting the setup prompt from the [clawr.ing dashboard](https://clawr.ing) into your OpenClaw chat. No CLI install needed.
+
+That's it. No other dependencies. The setup prompt includes the API key and links to skill docs — the agent reads them and figures out the rest.
+
+## Example: Morning Briefing Call
+
+Set up a cron job that calls you every morning with a personalized briefing:
+
+```
+Every weekday at 7:30 AM, call me with a morning briefing. Include:
+- Weather forecast for my city
+- My calendar for today
+- Any urgent emails that came in overnight
+- Top 3 news headlines relevant to my interests
+
+Keep it concise — aim for under 2 minutes. If I ask questions, answer them.
+If I don't pick up, don't retry.
+```
+
+## Example: Price Alert
+
+Tell the agent what to watch and when to call:
+
+```
+Monitor NVDA stock price. If it drops more than 5% in a single day,
+call me immediately and tell me what happened. Include any relevant
+news that might explain the drop.
+```
+
+## Example: Urgent Email Filter
+
+```
+During business hours, check my inbox every 15 minutes.
+If you see an email from my boss or any email marked urgent,
+call me with a summary. For everything else, just send a chat message.
+```
+
+## Key Insights
+
+- **Don't overuse it.** The whole point is that a phone call means "this actually matters." If your agent calls you 10 times a day, you'll start ignoring it. Set clear thresholds for what's call-worthy vs chat-worthy.
+- **Pair with heartbeat or cron.** clawr.ing is the delivery channel — you still need a trigger. Heartbeat checks (every 30 min) work for monitoring tasks. Cron jobs work for scheduled briefings.
+- **Two-way conversation.** Unlike a push notification, you can ask follow-up questions on the call. "Wait, which email?" or "What's the current price now?" — the agent responds in real time.
+- **Fast model for calls.** Phone conversations need quick responses. If your OpenClaw supports skill-level model routing, assign clawr.ing to a fast model (Haiku-class). The thinking sound covers latency, but faster is always better.
+- **Privacy.** clawr.ing doesn't store recordings or transcripts. Audio is encrypted in transit and discarded after processing.
+
+## Related Links
+
+- [clawr.ing](https://clawr.ing)
+- [clawr.ing on ClawHub](https://clawhub.ai/marcospgp/clawring)
+- [OpenClaw](https://github.com/openclaw/openclaw)


### PR DESCRIPTION
## Summary

Adds a new use case for **phone call notifications** using [clawr.ing](https://clawr.ing) — a managed calling skill that lets OpenClaw agents call users for urgent alerts, morning briefings, and time-sensitive notifications.

Key difference from existing phone use cases (ClawdTalk): clawr.ing is **outbound only** — the agent calls you, not the other way around. This is designed for proactive notifications, not on-demand assistance.

Includes three example prompts (morning briefing, price alert, urgent email filter) and practical tips for getting the most out of it.

- New file: `usecases/phone-call-notifications.md`
- README: added row to Productivity table, bumped use case count to 35