### PR TITLE
Add M365 Email Triage with Prefetch Architecture document

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-36-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-37-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)
@@ -75,6 +75,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Second Brain](usecases/second-brain.md) | Text anything to your bot to remember it, then search through all your memories in a custom Next.js dashboard. |
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
 | [Phone Call Notifications](usecases/phone-call-notifications.md) | Turn your agent's alerts into real phone calls — morning briefings, price drops, urgent emails — with two-way conversation. |
+| [M365 Email Triage with Prefetch](usecases/m365-email-triage-prefetch.md) | Two-stage email monitoring across M365 tenants — prefetch caches metadata cheaply, triage decides what's worth alerting, cutting token use by 99%. |
 
 ## Research & Learning
 

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -1,0 +1,175 @@
+# M365 Email Triage with Prefetch Architecture
+
+> Smart email monitoring across multiple Microsoft 365 tenants, with cost-optimized prefetching that cuts token use by 99% and intelligent triage that decides what's worth alerting you about — and what can wait.
+
+## The Problem
+
+If you use OpenClaw to monitor email, you've probably hit one of these walls:
+
+- **Cost explosion**: Every cron job triggers a full cache write of the system prompt. If you're checking email every 15 minutes, you're paying for 96 cold starts per day — before the agent even reads a message. At ~$0.20 per cold start on Claude Sonnet, that's $20/day just for email checking.
+- **Token bloat**: If your agent calls the M365 tool directly (via mcporter), it retrieves full HTML email bodies — CSS, tracking pixels, images, everything. A single inbox check can consume 1.45 million tokens. Your agent is eating entire rendered web pages for breakfast.
+- **Alert fatigue**: Without smart triage, you get pinged for every email — marketing, newsletters, automated receipts, stale messages — and you stop trusting the alerts.
+
+## What This Solves
+
+A two-stage architecture that separates **data gathering** (cheap, no LLM) from **intelligent triage** (LLM, but with minimal token input).
+
+**Stage 1 — Prefetch (system cron, no AI cost):**
+A Python script runs every 30 minutes during business hours. It calls mcporter to pull email metadata from multiple M365 tenants, strips reply chains, filters by time window, and writes a small JSON file. Cost: zero LLM tokens.
+
+**Stage 2 — Triage (OpenClaw cron, minimal tokens):**
+Seven minutes later, your OpenClaw agent reads the pre-built JSON file and makes judgment calls: what's urgent, what's routine, what can wait for the morning briefing. It delivers alerts via Telegram with emoji categorization and suggested actions. Cost: ~14K tokens instead of 1.45M.
+
+## Setup
+
+### Skills Required
+
+- **mcporter** (bundled) — Microsoft 365 integration
+- **message** or Telegram channel — for delivering alerts
+
+### Stage 1: The Prefetch Script
+
+Create a Python script that runs as a system cron job (not an OpenClaw cron — no LLM cost):
+
+```python
+#!/usr/bin/env python3
+"""Email prefetch — runs via system cron, writes JSON for OpenClaw to read."""
+import subprocess, json, os
+from datetime import datetime, timedelta, timezone
+
+CST = timezone(timedelta(hours=-6))
+LOOKBACK = timedelta(minutes=35)  # slightly wider than the 30-min interval
+OUTPUT = "/tmp/openclaw/email-monitor-pending.json"
+
+TENANTS = [
+    {"name": "Primary", "account": "user@company.com"},
+    {"name": "Secondary", "account": "user@otherdomain.com"},
+]
+
+def fetch_tenant(tenant):
+    since = (datetime.now(CST) - LOOKBACK).strftime("%Y-%m-%dT%H:%M:%S")
+    cmd = [
+        "openclaw", "skills", "call", "mcporter",
+        "--", "outlook", "mail", "list",
+        "--account", tenant["account"],
+        "--filter", f"receivedDateTime ge {since}",
+        "--select", "subject,from,receivedDateTime,isRead,bodyPreview",
+        "--top", "20",
+        "--output", "text"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    return json.loads(result.stdout) if result.returncode == 0 else []
+
+def strip_reply_chains(emails):
+    """Remove quoted reply content from bodyPreview to save tokens."""
+    for email in emails:
+        preview = email.get("bodyPreview", "")
+        for marker in ["From:", "-----Original", "On ", "> "]:
+            idx = preview.find(marker)
+            if idx > 50:  # keep at least 50 chars
+                preview = preview[:idx].rstrip()
+                break
+        email["bodyPreview"] = preview[:200]  # cap at 200 chars
+    return emails
+
+results = {}
+for tenant in TENANTS:
+    emails = fetch_tenant(tenant)
+    results[tenant["name"]] = strip_reply_chains(emails)
+
+os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
+with open(OUTPUT, "w") as f:
+    json.dump({"fetched_at": datetime.now(CST).isoformat(), "tenants": results}, f)
+```
+
+**System crontab** (runs every 30 minutes, 8 AM to 11 PM):
+```
+CRON_TZ=America/Chicago
+*/30 8-23 * * * /usr/bin/python3 /path/to/email-prefetch.py >> /tmp/openclaw/email-monitor.log 2>&1
+```
+
+### Stage 2: OpenClaw Cron Job
+
+Create an OpenClaw cron job that runs 7 minutes after the prefetch:
+
+```bash
+openclaw cron add \
+  --name "email-monitor" \
+  --schedule "7,37 8-23 * * *" \
+  --message "Read /tmp/openclaw/email-monitor-pending.json. Triage emails using EMAIL_MONITOR_PREFS.md rules. Alert me via Telegram only for items that need my attention. Use emoji categories and add → action lines for actionable items. Add a blank line between items. If nothing is actionable, skip the alert entirely."
+```
+
+### Stage 3: Triage Rules
+
+Create `~/.openclaw/workspace/EMAIL_MONITOR_PREFS.md`:
+
+```markdown
+# Email Monitor Preferences
+
+## Always Alert (regardless of time)
+- Financial transactions, payment failures, bank alerts
+- Security alerts from any service
+- VIP contacts (see VIP_CONTACTS.md)
+- Messages about children/dependents from schools, camps, caregivers
+
+## Alert During Business Hours
+- Client emails requiring response
+- Calendar invitations
+- Service outage notifications
+
+## Suppress / Morning Briefing Only
+- Marketing emails and newsletters
+- Automated receipts and confirmations
+- Social media notifications
+- Messages older than 6 hours (stale — not worth a late alert)
+
+## Formatting
+- 🔴 Urgent: needs response within 1 hour
+- 🟡 Actionable: needs response today
+- 🔵 Informational: FYI, no action needed
+- → Suggested action line for each actionable item
+```
+
+Create `~/.openclaw/workspace/VIP_CONTACTS.md`:
+```markdown
+# VIP Contacts — Always Surface
+- boss@company.com (Manager)
+- spouse@email.com (Family)
+- school@district.edu (Kids' school)
+```
+
+## Key mcporter Gotchas
+
+These cost us days of debugging. Save yourself the pain:
+
+1. **Always use `--select` with `bodyPreview`** instead of retrieving full email bodies. Without this, mcporter returns rendered HTML — CSS, images, tracking pixels — which breaks JSON parsing intermittently and consumes 100x more tokens.
+
+2. **Always use `--output text`** for clean JSON. The default output wraps responses in an MCP envelope that requires extra parsing.
+
+3. **Calendar date filtering is silently broken.** mcporter's `startdatetime` / `enddatetime` parameters for calendar queries don't actually filter. Retrieve all events and filter in Python post-fetch.
+
+## Results
+
+| Metric | Before (direct API) | After (prefetch) |
+|--------|-------------------|-------------------|
+| Tokens per check | ~1,450,000 | ~14,000 |
+| JSON parse failures | Intermittent | Zero |
+| Daily cost (email only) | ~$20+ | ~$1-2 |
+| False alert rate | High | Low (VIP + time-aware) |
+
+## Tips
+
+- **Stale message suppression** is the biggest quality-of-life win. If an email arrived 6 hours ago and it's 10 PM, your agent should skip it rather than buzzing your phone. It'll show up in the morning briefing.
+- **Reply chain stripping** matters more than you'd think. Without it, a 10-message email thread sends the full history on every check. Cap `bodyPreview` at 200 characters.
+- **The 7-minute offset** between prefetch and triage ensures the JSON file is always fresh when the agent reads it. Without the offset, race conditions cause the agent to read stale or partially-written data.
+- **Multi-tenant is free.** The prefetch script loops through tenants sequentially. Adding another M365 account is one line in the config.
+
+## Why Prefetch Instead of Direct Tool Calls?
+
+Every OpenClaw cron job triggers a full system prompt cache write (~$0.20 on Claude Sonnet with a typical workspace). That's the fixed cost of waking the agent up. If the agent then makes 3-4 mcporter tool calls to check multiple inboxes, each call adds round-trip latency and token consumption.
+
+The prefetch pattern inverts this: spend zero on data gathering (Python + system cron), then give the agent a single, pre-digested JSON file to reason about. One cache write, one file read, one triage decision. The agent's job is judgment, not data collection.
+
+## Attribution
+
+Developed as part of the Triss Manifold project — a production OpenClaw deployment running on a Beelink SER5 mini PC, managing email triage across multiple M365 tenants for a managed services provider. Running daily since February 2026.

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -84,6 +84,7 @@ for tenant in TENANTS:
     results[tenant["name"]] = strip_reply_chains(emails)
 
 os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
+tmp_output = None
 try:
     fd, tmp_output = tempfile.mkstemp(dir=os.path.dirname(OUTPUT), suffix=".json")
     with os.fdopen(fd, "w") as f:
@@ -91,7 +92,7 @@ try:
     os.replace(tmp_output, OUTPUT)
 except (OSError, IOError) as e:
     print(f"ERROR: Failed to write {OUTPUT}: {e}")
-    if os.path.exists(tmp_output):
+    if tmp_output and os.path.exists(tmp_output):
         os.remove(tmp_output)
 ```
 

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -58,7 +58,10 @@ def fetch_tenant(tenant):
         "--top", "20",
         "--output", "text"
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        return []
     if result.returncode != 0:
         return []
     try:

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -35,9 +35,10 @@ Create a Python script that runs as a system cron job (not an OpenClaw cron — 
 #!/usr/bin/env python3
 """Email prefetch — runs via system cron, writes JSON for OpenClaw to read."""
 import subprocess, json, os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo  # Python 3.9+; handles DST automatically
 
-CST = timezone(timedelta(hours=-6))
+CST = ZoneInfo("America/Chicago")
 LOOKBACK = timedelta(minutes=35)  # slightly wider than the 30-min interval
 OUTPUT = "/tmp/openclaw/email-monitor-pending.json"
 

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -34,8 +34,8 @@ Create a Python script that runs as a system cron job (not an OpenClaw cron — 
 ```python
 #!/usr/bin/env python3
 """Email prefetch — runs via system cron, writes JSON for OpenClaw to read."""
-import subprocess, json, os
-from datetime import datetime, timedelta
+import subprocess, json, os, tempfile
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo  # Python 3.9+; handles DST automatically
 
 CST = ZoneInfo("America/Chicago")
@@ -48,7 +48,7 @@ TENANTS = [
 ]
 
 def fetch_tenant(tenant):
-    since = (datetime.now(CST) - LOOKBACK).strftime("%Y-%m-%dT%H:%M:%S")
+    since = (datetime.now(CST) - LOOKBACK).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     cmd = [
         "openclaw", "skills", "call", "mcporter",
         "--", "outlook", "mail", "list",
@@ -84,10 +84,15 @@ for tenant in TENANTS:
     results[tenant["name"]] = strip_reply_chains(emails)
 
 os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
-tmp_output = f"{OUTPUT}.tmp"
-with open(tmp_output, "w") as f:
-    json.dump({"fetched_at": datetime.now(CST).isoformat(), "tenants": results}, f)
-os.replace(tmp_output, OUTPUT)
+try:
+    fd, tmp_output = tempfile.mkstemp(dir=os.path.dirname(OUTPUT), suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        json.dump({"fetched_at": datetime.now(CST).isoformat(), "tenants": results}, f)
+    os.replace(tmp_output, OUTPUT)
+except (OSError, IOError) as e:
+    print(f"ERROR: Failed to write {OUTPUT}: {e}")
+    if os.path.exists(tmp_output):
+        os.remove(tmp_output)
 ```
 
 **System crontab** (runs every 30 minutes, 8 AM to 11 PM):

--- a/usecases/m365-email-triage-prefetch.md
+++ b/usecases/m365-email-triage-prefetch.md
@@ -58,7 +58,12 @@ def fetch_tenant(tenant):
         "--output", "text"
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    return json.loads(result.stdout) if result.returncode == 0 else []
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
 
 def strip_reply_chains(emails):
     """Remove quoted reply content from bodyPreview to save tokens."""
@@ -78,12 +83,14 @@ for tenant in TENANTS:
     results[tenant["name"]] = strip_reply_chains(emails)
 
 os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
-with open(OUTPUT, "w") as f:
+tmp_output = f"{OUTPUT}.tmp"
+with open(tmp_output, "w") as f:
     json.dump({"fetched_at": datetime.now(CST).isoformat(), "tenants": results}, f)
+os.replace(tmp_output, OUTPUT)
 ```
 
 **System crontab** (runs every 30 minutes, 8 AM to 11 PM):
-```
+```bash
 CRON_TZ=America/Chicago
 */30 8-23 * * * /usr/bin/python3 /path/to/email-prefetch.py >> /tmp/openclaw/email-monitor.log 2>&1
 ```


### PR DESCRIPTION
Document the architecture for M365 email triage with prefetching, detailing the problem, solution, setup, and results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide describing a two-stage prefetch → triage workflow for M365 email monitoring.
  * Provides setup steps, examples for configuring prefetch and triage schedules, triage rules, alert formatting, and operational best practices.
  * Includes guidance on handling stale messages and reply chains, multi-tenant considerations, and results showing token/cost optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->