### PR TITLE
Add WatchClaw link to Self-Healing Home Server use case

### DIFF
--- a/usecases/self-healing-home-server.md
+++ b/usecases/self-healing-home-server.md
@@ -174,6 +174,7 @@ Also referenced on the [OpenClaw Showcase](https://openclaw.ai/showcase), where 
 
 ## Related Links
 
+- [WatchClaw](https://github.com/kashifeqbal/watchclaw) — autonomous security/ops hardening layer for OpenClaw deployments (self-healing checks, Cowrie honeypot automation, canary checks, alerting)
 - [Nathan's Full Writeup](https://madebynathan.com/2026/02/03/everything-ive-done-with-openclaw-so-far/)
 - [OpenClaw Documentation](https://github.com/openclaw/openclaw)
 - [TruffleHog (Secret Scanning)](https://github.com/trufflesecurity/trufflehog)


### PR DESCRIPTION
## Summary
Adds [WatchClaw](https://github.com/kashifeqbal/watchclaw) under **Related Links** in the Self-Healing Home Server use case file.

## Why
The use case already focuses on autonomous infrastructure operations (self-healing checks, alerting, security workflows). WatchClaw is a concrete implementation aligned with that pattern, so this gives readers a direct reference project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the related resources section in the self-healing home server documentation with an additional reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->