### PR TITLE
Add arXiv Paper Reader & LaTeX Paper Writing use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Market Research & Product Factory](usecases/market-research-product-factory.md) | Mine Reddit and X for real pain points using the Last 30 Days skill, then have OpenClaw build MVPs that solve them. |
 | [Pre-Build Idea Validator](usecases/pre-build-idea-validator.md) | Automatically scan GitHub, HN, npm, PyPI, and Product Hunt before building anything new — stop if the space is crowded, proceed if it's open. |
 | [Semantic Memory Search](usecases/semantic-memory-search.md) | Add vector-powered semantic search to your OpenClaw markdown memory files with hybrid retrieval and auto-sync. |
+| [arXiv Paper Reader](usecases/arxiv-paper-reader.md) | Read and analyze arXiv papers conversationally — fetch by ID, browse sections, compare abstracts, and get AI summaries. |
+| [LaTeX Paper Writing](usecases/latex-paper-writing.md) | Write and compile LaTeX papers conversationally with instant PDF preview — no local TeX installation needed. |
 
 ## Finance & Trading
 

--- a/usecases/arxiv-paper-reader.md
+++ b/usecases/arxiv-paper-reader.md
@@ -22,7 +22,7 @@ This workflow turns your agent into a research reading assistant:
 docker compose -f docker/docker-compose.dev.yml up
 ```
 
-2. The `arxiv-reader` skill is builtin — no installation needed. Prompt OpenClaw:
+2. The `arxiv-reader` skill is built-in — no installation needed. Prompt OpenClaw:
 ```text
 I'm researching [topic]. Here's my workflow:
 

--- a/usecases/arxiv-paper-reader.md
+++ b/usecases/arxiv-paper-reader.md
@@ -1,0 +1,45 @@
+# arXiv Paper Reader
+
+Reading arXiv papers means downloading PDFs, losing context when switching between papers, and struggling to parse dense LaTeX notation. You want to read, analyze, and compare papers conversationally without leaving your workspace.
+
+This workflow turns your agent into a research reading assistant:
+
+- Fetch any arXiv paper by ID and get clean, readable text (LaTeX flattened automatically)
+- Browse paper structure first — list sections to decide what to read before committing to the full text
+- Quick-scan abstracts across multiple papers to triage a reading list
+- Ask the agent to summarize, compare, or critique specific sections
+- Results are cached locally — revisiting a paper is instant
+
+## Skills you Need
+
+- [arxiv-reader](https://github.com/Prismer-AI/Prismer/tree/main/skills/arxiv-reader) skill (3 tools: `arxiv_fetch`, `arxiv_sections`, `arxiv_abstract`)
+- Prismer workspace container (runs the arXiv server on port 8082)
+
+## How to Set it Up
+
+1. Deploy Prismer with Docker (the arXiv server starts automatically):
+```bash
+docker compose -f docker/docker-compose.dev.yml up
+```
+
+2. The `arxiv-reader` skill is builtin — no installation needed. Prompt OpenClaw:
+```text
+I'm researching [topic]. Here's my workflow:
+
+1. When I give you an arXiv ID (like 2301.00001):
+   - First fetch the abstract so I can decide if it's relevant
+   - If I say "read it", fetch the full paper (remove appendix by default)
+   - Summarize the key contributions, methodology, and results
+
+2. When I give you multiple IDs:
+   - Fetch all abstracts and give me a comparison table
+   - Rank them by relevance to my research topic
+
+3. When I ask about a specific section:
+   - List the paper's sections first
+   - Then fetch and explain the relevant section in detail
+
+Keep a running list of papers I've read and their key takeaways.
+```
+
+3. Try it: "Read 2401.04088 — what's the main contribution?"

--- a/usecases/arxiv-paper-reader.md
+++ b/usecases/arxiv-paper-reader.md
@@ -17,8 +17,9 @@ This workflow turns your agent into a research reading assistant:
 
 ## How to Set it Up
 
-1. Deploy Prismer with Docker (the arXiv server starts automatically):
+1. Clone and deploy [Prismer](https://github.com/Prismer-AI/Prismer) with Docker (the arXiv server starts automatically):
 ```bash
+git clone https://github.com/Prismer-AI/Prismer.git && cd Prismer
 docker compose -f docker/docker-compose.dev.yml up
 ```
 

--- a/usecases/arxiv-paper-reader.md
+++ b/usecases/arxiv-paper-reader.md
@@ -13,17 +13,14 @@ This workflow turns your agent into a research reading assistant:
 ## Skills you Need
 
 - [arxiv-reader](https://github.com/Prismer-AI/Prismer/tree/main/skills/arxiv-reader) skill (3 tools: `arxiv_fetch`, `arxiv_sections`, `arxiv_abstract`)
-- Prismer workspace container (runs the arXiv server on port 8082)
+
+No Docker or Python required — the skill runs standalone using Node.js built-ins. It downloads directly from arXiv, decompresses the LaTeX source, and flattens includes automatically.
 
 ## How to Set it Up
 
-1. Clone and deploy [Prismer](https://github.com/Prismer-AI/Prismer) with Docker (the arXiv server starts automatically):
-```bash
-git clone https://github.com/Prismer-AI/Prismer.git && cd Prismer
-docker compose -f docker/docker-compose.dev.yml up
-```
+1. Install the `arxiv-reader` skill from the [Prismer repository](https://github.com/Prismer-AI/Prismer/tree/main/skills/arxiv-reader) — copy the `skills/arxiv-reader/` directory into your OpenClaw skills folder.
 
-2. The `arxiv-reader` skill is built-in — no installation needed. Prompt OpenClaw:
+2. The skill is ready to use. Prompt OpenClaw:
 ```text
 I'm researching [topic]. Here's my workflow:
 

--- a/usecases/latex-paper-writing.md
+++ b/usecases/latex-paper-writing.md
@@ -1,0 +1,39 @@
+# LaTeX Paper Writing
+
+Setting up a local LaTeX environment is painful — installing TeX Live takes gigabytes, debugging compilation errors is tedious, and switching between your editor and PDF viewer breaks flow. You want to write and compile LaTeX papers conversationally without any local setup.
+
+This workflow turns your agent into a LaTeX writing assistant with instant compilation:
+
+- Write LaTeX collaboratively with the agent — describe what you want and it generates the source
+- Compile to PDF instantly with pdflatex, xelatex, or lualatex (no local TeX installation needed)
+- Preview PDFs inline without switching to another app
+- Use starter templates (article, IEEE, beamer, Chinese article) to skip boilerplate
+- Bibliography support with BibTeX/BibLaTeX — just paste your .bib content
+
+## Skills you Need
+
+- [latex-compiler](https://github.com/Prismer-AI/Prismer/tree/main/skills/latex-compiler) skill (4 tools: `latex_compile`, `latex_preview`, `latex_templates`, `latex_get_template`)
+- Prismer workspace container (runs the LaTeX server on port 8080 with full TeX Live)
+
+## How to Set it Up
+
+1. Deploy Prismer with Docker (the LaTeX server with full TeX Live starts automatically):
+```bash
+docker compose -f docker/docker-compose.dev.yml up
+```
+
+2. The `latex-compiler` skill is builtin — no installation needed. Prompt OpenClaw:
+```text
+Help me write a research paper in LaTeX. Here's my workflow:
+
+1. Start from the IEEE template (or article/beamer depending on what I need)
+2. When I describe a section, generate the LaTeX source for it
+3. After each major edit, compile and preview the PDF so I can check formatting
+4. If there are compilation errors, read the log and fix them automatically
+5. When I provide BibTeX entries, add them to the bibliography and recompile
+
+Use xelatex if I need Chinese/CJK support, otherwise default to pdflatex.
+Always run 2 passes for cross-references.
+```
+
+3. Try it: "Start a new IEEE paper titled 'A Survey of LLM Agents'. Give me the template with abstract and introduction sections filled in, then compile it."

--- a/usecases/latex-paper-writing.md
+++ b/usecases/latex-paper-writing.md
@@ -22,7 +22,7 @@ This workflow turns your agent into a LaTeX writing assistant with instant compi
 docker compose -f docker/docker-compose.dev.yml up
 ```
 
-2. The `latex-compiler` skill is builtin — no installation needed. Prompt OpenClaw:
+2. The `latex-compiler` skill is built-in — no installation needed. Prompt OpenClaw:
 ```text
 Help me write a research paper in LaTeX. Here's my workflow:
 

--- a/usecases/latex-paper-writing.md
+++ b/usecases/latex-paper-writing.md
@@ -17,8 +17,9 @@ This workflow turns your agent into a LaTeX writing assistant with instant compi
 
 ## How to Set it Up
 
-1. Deploy Prismer with Docker (the LaTeX server with full TeX Live starts automatically):
+1. Clone and deploy [Prismer](https://github.com/Prismer-AI/Prismer) with Docker (the LaTeX server with full TeX Live starts automatically):
 ```bash
+git clone https://github.com/Prismer-AI/Prismer.git && cd Prismer
 docker compose -f docker/docker-compose.dev.yml up
 ```
 


### PR DESCRIPTION
## Summary

Two academic research use cases powered by [Prismer](https://github.com/Prismer-AI/Prismer)'s builtin OpenClaw skills:

- **arXiv Paper Reader** — Conversational arXiv paper reading: fetch papers by ID, browse section structure, compare abstracts across papers, and get AI-powered summaries. Uses the `arxiv-reader` skill (3 tools).
- **LaTeX Paper Writing** — Write and compile LaTeX papers conversationally with instant PDF preview. Supports pdflatex/xelatex/lualatex, bibliography, and starter templates (article, IEEE, beamer). No local TeX installation needed. Uses the `latex-compiler` skill (4 tools).

Both run inside a self-hosted Docker container — one `docker compose up` and you're ready.

## Verification

Both skills are builtin to Prismer and have been tested in daily use for academic paper reading and writing workflows.

## Checklist

- [x] One use case per markdown file
- [x] README table updated with both entries (Research & Learning section)
- [x] Concise and replicable setup instructions
- [x] No crypto-related content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an arXiv Paper Reader use case describing fetching and flattening papers, structured section browsing before reading, quick abstract triage across papers, summarization/comparison/critique of sections, local caching, reading-list management, and example interaction prompts.
  * Added a LaTeX Paper Writing use case describing collaborative LaTeX editing with starter templates, bibliography support, instant PDF compilation and inline previews, automatic compile-fix behavior, and example prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->