### PR TITLE
feat: add Home Server Plugin OS use case using miniclaw-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
+| [Home Server Plugin OS (miniclaw-os)](usecases/home-server-plugin-os.md) | Deploy miniclaw-os on a Mac mini for a fully autonomous personal AI OS — 9 plugins covering task boards, SEO, email, vector KB, image gen, desktop control, YouTube pipeline, blog automation, and inter-agent trust. |
 
 ## Productivity
 

--- a/usecases/home-server-plugin-os.md
+++ b/usecases/home-server-plugin-os.md
@@ -1,0 +1,65 @@
+# Home Server Plugin OS with miniclaw-os
+
+Running OpenClaw on a Mac mini home server unlocks a level of automation most agents can't reach — persistent 24/7 uptime, local file access, desktop GUI control, and a full suite of specialized plugins working together as an OS.
+
+This use case shows how to deploy [miniclaw-os](https://github.com/augmentedmike/miniclaw-os), a batteries-included OpenClaw plugin ecosystem, to turn a Mac mini into a fully autonomous personal AI OS.
+
+## Pain Point
+
+OpenClaw out of the box is powerful but requires you to wire up every capability yourself. Want SEO tracking? Build it. Want a task board? Build it. Want email automation? Build it. For a home server deployment meant to run 24/7 autonomously, you need a cohesive plugin ecosystem — not a collection of standalone hacks.
+
+## What miniclaw-os Does
+
+miniclaw-os provides a suite of OS-level OpenClaw plugins that compose into a complete autonomous home server stack:
+
+| Plugin | What It Does |
+|--------|-------------|
+| **mc-board** | Kanban task board with board-worker agents that autonomously execute cards |
+| **mc-seo** | SEO rank tracking (Google/Bing/DuckDuckGo), backlink outreach, sitemap pinging |
+| **mc-email** | Multi-account IMAP/SMTP email — Amelia persona + personal Gmail — with Telegram delivery |
+| **mc-kb** | Vector knowledge base with semantic search (sqlite-vec) |
+| **mc-designer** | AI image generation pipeline via Gemini |
+| **mc-human** | VNC desktop control for GUI automation of apps without APIs |
+| **mc-youtube** | YouTube video production — script → voiceover → upload pipeline |
+| **mc-substack** | Substack cross-posting with smart excerpt generation |
+| **mc-trust** | HMAC-signed inter-agent message trust verification |
+
+## Real-World Workflow
+
+A typical day for a miniclaw-os home server:
+
+1. **Morning**: Agent checks email (mc-email), creates task cards (mc-board), starts SEO rank check (mc-seo)
+2. **Daytime**: Board-worker agents autonomously execute queued cards — writing blog posts, designing assets (mc-designer), sending outreach emails
+3. **Evening**: SEO rank alerts sent to Telegram if rankings change; new YouTube video uploaded via mc-youtube pipeline
+4. **Overnight**: Cron jobs trigger Substack cross-posts (mc-substack), knowledge base indexed for next day (mc-kb)
+
+## Setup
+
+```bash
+# Install miniclaw-os plugins
+openclaw plugins install @miniclaw-os/mc-board
+openclaw plugins install @miniclaw-os/mc-seo
+openclaw plugins install @miniclaw-os/mc-email
+openclaw plugins install @miniclaw-os/mc-kb
+openclaw plugins install @miniclaw-os/mc-designer
+openclaw plugins install @miniclaw-os/mc-human
+```
+
+## Key Design Decisions
+
+- **SQLite everywhere** — no Docker, no Postgres, no Redis. Every plugin stores state in local SQLite for zero-ops persistence.
+- **Telegram as the interface** — all alerts, task updates, and approvals flow through Telegram for async mobile access.
+- **Board-worker pattern** — mc-board spawns subagents that execute task cards autonomously, reporting back when done.
+- **HMAC trust** — mc-trust signs inter-agent messages so the server rejects injected instructions from untrusted sources.
+
+## Who This Is For
+
+- Home lab enthusiasts running Mac mini as a 24/7 server
+- Developers building autonomous agent workflows who want a production-ready baseline
+- OpenClaw users who want to skip the "build every plugin yourself" phase
+
+## Links
+
+- GitHub: https://github.com/augmentedmike/miniclaw-os
+- Live example: https://helloam.bot (Amelia — the bot persona running on this stack)
+- Bot interface: https://miniclaw.bot


### PR DESCRIPTION
## New Use Case: Home Server Plugin OS with miniclaw-os

This PR adds a real-world use case for running OpenClaw as a fully autonomous home server using [miniclaw-os](https://github.com/augmentedmike/miniclaw-os), a batteries-included plugin ecosystem for Mac mini.

## What this use case covers

- **Problem**: OpenClaw is powerful but wiring every capability manually is slow
- **Solution**: miniclaw-os — 9 production-ready plugins that compose into an autonomous personal AI OS
- **Real workflow**: morning email check → autonomous task execution → evening SEO alerts → overnight cron automation

## Plugins demonstrated

mc-board, mc-seo, mc-email, mc-kb, mc-designer, mc-human, mc-youtube, mc-substack, mc-trust

## Why this fits here

This is a genuinely useful Infrastructure & DevOps use case that shows OpenClaw's potential for home server automation at scale. The miniclaw-os stack is running in production (helloam.bot) and represents a reference architecture for autonomous home AI.

## Files added

- `usecases/home-server-plugin-os.md` — full use case doc with setup guide and real-world workflow
- Updated `README.md` table under Infrastructure & DevOps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for deploying Home Server Plugin OS (miniclaw-os) on a Mac mini home server
  * Documentation includes available OS plugins, deployment setup commands, core design decisions, daily workflow examples, and target user information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->