### PR TITLE
Add PolyClawster Polymarket trading agent use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent skill for trading on Polymarket prediction markets. Non-custodial, whale signal detection, public leaderboard. Works as OpenClaw skill or Telegram Mini App.
 - Add a new usecase
 - Improve existing ones
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-- [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent skill for trading on Polymarket prediction markets. Non-custodial, whale signal detection, public leaderboard. Works as OpenClaw skill or Telegram Mini App.
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent that autonomously monitors prediction market signals, detects smart-money patterns, and executes decisions — demonstrating event-driven autonomous reasoning with non-custodial local execution.
 - Add a new usecase
 - Improve existing ones
 


### PR DESCRIPTION
PolyClawster is an AI agent that autonomously trades on Polymarket prediction markets. Tracks 200+ whale wallets, non-custodial execution.

Framed as an automation/productivity use case for OpenClaw agents.

https://github.com/al1enjesus/polyclawster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new reference to PolyClawster in the Contributing section.
  * Documentation-only update; no behavioral or functional changes to the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->