### PR TITLE
Add use case: Cloud Backup and Disaster Recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-36-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-37-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
+| [Cloud Backup and Disaster Recovery](usecases/cloud-backup-disaster-recovery.md) | Automated encrypted cloud backups of your OpenClaw workspace with cross-machine restore and safe restore drills. |
 
 ## Productivity
 

--- a/usecases/cloud-backup-disaster-recovery.md
+++ b/usecases/cloud-backup-disaster-recovery.md
@@ -1,0 +1,70 @@
+# Cloud Backup and Disaster Recovery for OpenClaw
+
+## Pain Point
+
+OpenClaw agents accumulate valuable state over time: memory files, cron jobs, skills, credentials, and configuration. A disk failure, OS reinstall, or machine migration can wipe all of it. Manual backup approaches (git, rsync, Time Machine) either miss credentials, don't encrypt at rest, or don't work across machines.
+
+## What It Does
+
+Sets up automated encrypted cloud backups of your entire OpenClaw workspace. Backups run on a schedule via cron, encrypt everything client-side before upload, and store encrypted snapshots in cloud storage. You can restore to the same machine or a completely different one with a single command. Includes a safe restore drill that verifies recovery works without touching your live workspace.
+
+## Prompts
+
+### Initial Setup
+
+```
+Install the keepmyclaw skill and configure daily encrypted backups of my workspace.
+```
+
+### Verify First Backup
+
+```
+Run a backup now and verify the snapshot was uploaded successfully. List my snapshots to confirm.
+```
+
+### Safe Restore Drill
+
+```
+Run a restore drill into /tmp/keepmyclaw-restore-check so I can verify recovery works without touching my live workspace.
+```
+
+### Migrate to New Machine
+
+On the new machine after installing OpenClaw:
+
+```
+Install keepmyclaw and restore my latest backup from the cloud.
+```
+
+## Skills Needed
+
+- [keepmyclaw](https://clawhub.ai/Ryce/keepmyclaw) — Encrypted cloud backup and restore for OpenClaw workspaces
+
+```bash
+clawhub install keepmyclaw
+```
+
+## What Gets Backed Up
+
+- Workspace files (MEMORY.md, SOUL.md, USER.md, etc.)
+- Memory directory (daily notes, long-term memory)
+- Cron job configurations
+- Installed skills
+- Credentials and API keys (encrypted client-side)
+- Config snapshots
+
+## How It Works
+
+1. Everything is encrypted locally with your passphrase before leaving your machine
+2. Encrypted snapshots are uploaded to Cloudflare R2 cloud storage
+3. The server never sees plaintext — only you can decrypt with your passphrase
+4. Cron job runs backups automatically on your chosen schedule (daily recommended)
+5. Restore pulls the encrypted snapshot and decrypts locally
+
+## Related Links
+
+- [Keep My Claw](https://keepmyclaw.com) — Product page and pricing
+- [Setup Guide](https://keepmyclaw.com/docs) — Full documentation
+- [How to Verify Your First Backup](https://keepmyclaw.com/blog/openclaw-first-backup-proof.html)
+- [Restoring Onto a Different Machine](https://keepmyclaw.com/blog/openclaw-new-machine-restore.html)
+- [Backup Checklist](https://keepmyclaw.com/blog/openclaw-backup-checklist.html)

--- a/usecases/cloud-backup-disaster-recovery.md
+++ b/usecases/cloud-backup-disaster-recovery.md
@@ -25,7 +25,7 @@ Run a backup now and verify the snapshot was uploaded successfully. List my snap
 ### Safe Restore Drill
 
 ```text
-Run a restore drill into /tmp/keepmyclaw-restore-check so I can verify recovery works without touching my live workspace.
+Run a restore drill into a temporary directory such as /tmp/keepmyclaw-restore-check so I can verify recovery works without touching my live workspace.
 ```
 
 ### Migrate to New Machine
@@ -60,6 +60,8 @@ clawhub install keepmyclaw
 3. The server never sees plaintext — only you can decrypt with your passphrase
 4. Cron job runs backups automatically on your chosen schedule (daily recommended)
 5. Restore pulls the encrypted snapshot and decrypts locally
+
+> **⚠️ Passphrase Recovery:** Your encryption passphrase is the only way to decrypt backups. Store it outside your OpenClaw workspace (e.g., in a password manager or printed offline backup). If you lose the passphrase, cloud snapshots cannot be restored.
 
 ## Related Links
 

--- a/usecases/cloud-backup-disaster-recovery.md
+++ b/usecases/cloud-backup-disaster-recovery.md
@@ -12,19 +12,19 @@ Sets up automated encrypted cloud backups of your entire OpenClaw workspace. Bac
 
 ### Initial Setup
 
-```
+```text
 Install the keepmyclaw skill and configure daily encrypted backups of my workspace.
 ```
 
 ### Verify First Backup
 
-```
+```text
 Run a backup now and verify the snapshot was uploaded successfully. List my snapshots to confirm.
 ```
 
 ### Safe Restore Drill
 
-```
+```text
 Run a restore drill into /tmp/keepmyclaw-restore-check so I can verify recovery works without touching my live workspace.
 ```
 
@@ -32,7 +32,7 @@ Run a restore drill into /tmp/keepmyclaw-restore-check so I can verify recovery 
 
 On the new machine after installing OpenClaw:
 
-```
+```text
 Install keepmyclaw and restore my latest backup from the cloud.
 ```
 


### PR DESCRIPTION
## Use Case

**Cloud Backup and Disaster Recovery** — Automated encrypted cloud backups of your OpenClaw workspace with cross-machine restore and safe restore drills.

## Category

Infrastructure & DevOps

## What It Covers

- Pain point: losing agent state (memory, cron, skills, credentials) to disk failure, reinstall, or migration
- Automated daily encrypted backups via cron
- Client-side encryption (server never sees plaintext)
- Cross-machine restore with one command
- Safe restore drill to verify recovery without touching live workspace

## Skill Used

- [keepmyclaw](https://clawhub.ai/Ryce/keepmyclaw) (`clawhub install keepmyclaw`)

## Tested

Yes — running in production with daily automated backups and verified restore drills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed Cloud Backup & Disaster Recovery guidance: automated client-side encrypted cloud backups, cross-machine restore, and safe-restore drills.
  * Covers what is backed up (workspace files, snapshots, configs, components), backup/restore workflows, initial setup and verification, migration to a new machine, passphrase recovery guidance, required skills, and reference checklists and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->