### PR TITLE
feat: add Image Generation use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Multi-Agent Content Factory](usecases/content-factory.md) | Run a multi-agent content pipeline in Discord — research, writing, and thumbnail agents working in dedicated channels. |
 | [Autonomous Game Dev Pipeline](usecases/autonomous-game-dev-pipeline.md) | Full lifecycle management of educational game development: from backlog selection to implementation, registration, documentation, and git commit. Enforces "Bugs First" policy. |
 | [Podcast Production Pipeline](usecases/podcast-production-pipeline.md) | Automate the full podcast workflow — guest research, episode outlines, show notes, and social media promo — from topic to publish-ready assets. |
-| [Neta Character Image Generation](usecases/neta-character-image-generation.md) | Generate AI images of your adopted Neta character in any scene, style, or aspect ratio — directly from chat, no web UI needed. |
+| [Character Image Generation](usecases/neta-character-image-generation.md) | Generate AI images of your adopted character in any scene, style, or aspect ratio — directly from chat, no web UI needed. |
 
 ## Infrastructure & DevOps
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Multi-Agent Content Factory](usecases/content-factory.md) | Run a multi-agent content pipeline in Discord — research, writing, and thumbnail agents working in dedicated channels. |
 | [Autonomous Game Dev Pipeline](usecases/autonomous-game-dev-pipeline.md) | Full lifecycle management of educational game development: from backlog selection to implementation, registration, documentation, and git commit. Enforces "Bugs First" policy. |
 | [Podcast Production Pipeline](usecases/podcast-production-pipeline.md) | Automate the full podcast workflow — guest research, episode outlines, show notes, and social media promo — from topic to publish-ready assets. |
+| [Neta Character Image Generation](usecases/neta-character-image-generation.md) | Generate AI images of your adopted Neta character in any scene, style, or aspect ratio — directly from chat, no web UI needed. |
 
 ## Infrastructure & DevOps
 

--- a/usecases/neta-character-image-generation.md
+++ b/usecases/neta-character-image-generation.md
@@ -1,0 +1,62 @@
+# Neta Character Image Generation
+
+Generate AI images of your adopted Neta character in any scene, style, or mood — directly from chat.
+
+## Pain Point
+
+Creating images on the Neta platform normally requires navigating the web UI, searching for scenes manually, and tweaking settings by hand. There's no way to just describe what you want in natural language and get an image back without leaving your workflow.
+
+## What It Does
+
+Using the `image-generation-claw-skill`, OpenClaw reads your character from `SOUL.md`, resolves it to a character vtoken via the Neta API, builds a structured prompt, submits an image generation job, polls until complete, and returns the image URL — all from a single chat message like:
+
+> *"Draw 关羽 in a rainy bamboo forest, cinematic lighting, portrait"*
+
+Supports:
+- Custom prompts in natural language
+- Art styles (manga, oil painting, watercolor, cinematic, pixel art, etc.)
+- Aspect ratios: portrait, landscape, square, tall
+- Extra reference images for style/consistency control
+- Character search if you want to switch characters mid-session
+
+## Prompts
+
+```
+Draw [character name] in [scene description], [style], [mood]
+```
+
+```
+Generate a landscape banner of [character] with dramatic lighting
+```
+
+```
+Same character, watercolor style, autumn forest
+```
+
+```
+Show me style options
+```
+
+## Skills Needed
+
+- [`image-generation-claw-skill`](https://github.com/tonyclawskill/image-generation-claw-skill) — zero-dependency Node.js helper, no neta-skills install required
+- A `SOUL.md` file with your adopted character (created by the `adopt` skill)
+- `NETA_TOKEN` in `~/.openclaw/workspace/.env`
+
+## Example Output
+
+> 🔍 Looking up character: 关羽...
+> ✅ Character resolved: 关羽
+> 🎨 Generating image (576×768)...
+> ⏳ Task submitted: 3835c8de-...
+>
+> ━━━━━━━━━━━━━━━━━━━━━━━━
+> ✨ 关羽 · rainy bamboo forest, cinematic
+> https://oss.talesofai.cn/picture/3835c8de-...webp
+> ━━━━━━━━━━━━━━━━━━━━━━━━
+
+## Related Links
+
+- [Neta Art Platform](https://talesofai.cn)
+- [neta-skills reference](https://github.com/talesofai/neta-skills)
+- [travelclaw — character adventure skill](https://github.com/talesofai/travelclaw)

--- a/usecases/neta-character-image-generation.md
+++ b/usecases/neta-character-image-generation.md
@@ -1,14 +1,14 @@
-# Neta Character Image Generation
+# Character Image Generation
 
-Generate AI images of your adopted Neta character in any scene, style, or mood — directly from chat.
+Generate AI images of your adopted character in any scene, style, or mood — directly from chat.
 
 ## Pain Point
 
-Creating images on the Neta platform normally requires navigating the web UI, searching for scenes manually, and tweaking settings by hand. There's no way to just describe what you want in natural language and get an image back without leaving your workflow.
+Creating character images normally requires navigating the platform web UI, searching for scenes manually, and tweaking settings by hand. There's no way to just describe what you want in natural language and get an image back without leaving your workflow.
 
 ## What It Does
 
-Using the `image-generation-claw-skill`, OpenClaw reads your character from `SOUL.md`, resolves it to a character vtoken via the Neta API, builds a structured prompt, submits an image generation job, polls until complete, and returns the image URL — all from a single chat message like:
+Using the `image-generation-claw-skill`, OpenClaw reads your character from `SOUL.md`, resolves it to a character vtoken, builds a structured prompt, submits an image generation job, polls until complete, and returns the image URL — all from a single chat message like:
 
 > *"Draw 关羽 in a rainy bamboo forest, cinematic lighting, portrait"*
 
@@ -39,9 +39,9 @@ Show me style options
 
 ## Skills Needed
 
-- [`image-generation-claw-skill`](https://github.com/tonyclawskill/image-generation-claw-skill) — zero-dependency Node.js helper, no neta-skills install required
+- [`image-generation-claw-skill`](https://github.com/tonyclawskill/image-generation-claw-skill) — zero-dependency Node.js helper
 - A `SOUL.md` file with your adopted character (created by the `adopt` skill)
-- `NETA_TOKEN` in `~/.openclaw/workspace/.env`
+- API token in `~/.openclaw/workspace/.env`
 
 ## Example Output
 
@@ -57,6 +57,5 @@ Show me style options
 
 ## Related Links
 
-- [Neta Art Platform](https://talesofai.cn)
-- [neta-skills reference](https://github.com/talesofai/neta-skills)
+- [image-generation-claw-skill](https://github.com/tonyclawskill/image-generation-claw-skill)
 - [travelclaw — character adventure skill](https://github.com/talesofai/travelclaw)


### PR DESCRIPTION
## Summary

- Adds a new use case under **Creative & Building**: generating AI images of adopted Neta characters directly from chat
- Includes skill reference, example prompts, and sample output
- Personally tested and verified — images generated via the Neta API using the linked skill

## Use Case

**Pain point:** Creating character images on Neta requires manually navigating the web UI. There's no natural language interface.

**Solution:** [`image-generation-claw-skill`](https://github.com/tonyclawskill/image-generation-claw-skill) wraps the Neta image generation API — reads your character from `SOUL.md`, resolves vtokens, and returns an image URL from a single chat message.

## Test plan

- [x] Skill runs end-to-end (`soul` → `gen` → image URL returned)
- [x] Use case markdown follows existing format
- [x] Row added to README under correct category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Neta Character Image Generation use case: how to generate AI images directly from chat (no web UI), end-to-end workflow, supported capabilities (custom prompts, art styles, aspect ratios, reference images, mid-session character switching), prompt syntax samples, usage examples, example output trace, required skills/environment, and links to related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->