### PR TITLE
Add Agent Email Infrastructure use case (LobsterMail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Autonomous Project Management](usecases/autonomous-project-management.md) | Coordinate multi-agent projects using STATE.yaml pattern — subagents work in parallel without orchestrator overhead. |
 | [Multi-Channel AI Customer Service](usecases/multi-channel-customer-service.md) | Unify WhatsApp, Instagram, Email, and Google Reviews in one AI-powered inbox with 24/7 auto-responses. |
 | [Phone-Based Personal Assistant](usecases/phone-based-personal-assistant.md) | Access your AI agent via phone calls, hands-free voice assistance for any phone. |
+| [Agent Email Infrastructure](usecases/agent-email-infrastructure.md) | Give your agent its own email address — no human signup, no API keys. Uses LobsterMail skill. |
 | [Inbox De-clutter](usecases/inbox-declutter.md) | Summarize Newsletters and send you a digest as an email. |
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |
 | [Health & Symptom Tracker](usecases/health-symptom-tracker.md) | Track food intake and symptoms to identify triggers, with scheduled check-in reminders. |

--- a/usecases/agent-email-infrastructure.md
+++ b/usecases/agent-email-infrastructure.md
@@ -1,0 +1,34 @@
+# Agent Email Infrastructure
+
+Give your OpenClaw agent its own email address — no human signup, no API keys, no dashboard.
+
+## The Problem
+
+AI agents need to send and receive email for tasks like outreach, notifications, account verification, and communication. Traditional email providers require human signup flows, API key management, and dashboard configuration — none of which an autonomous agent can do.
+
+## The Solution
+
+Install the [LobsterMail skill](https://clawhub.ai/samuelchenardlovesboards/lobstermail-agent-email) and your agent can:
+
+- **Create its own inbox** in one line of code
+- **Send and receive email** autonomously  
+- **Stay safe** with prompt injection scanning across 6 categories
+- **Authenticate properly** with SPF/DKIM/DMARC built in
+
+## Quick Start
+
+```
+clawhub install lobstermail-agent-email
+```
+
+Then tell your agent: *"Create yourself an email address and send a test message."*
+
+## Skills Used
+
+- [lobstermail-agent-email](https://clawhub.ai/samuelchenardlovesboards/lobstermail-agent-email) — Email infrastructure for AI agents
+
+## Links
+
+- [LobsterMail](https://lobstermail.ai/) — Website
+- [Node.js SDK](https://www.npmjs.com/package/lobstermail) — `npm install lobstermail`
+- [MCP Server](https://lobstermail.ai/mcp) — For MCP-compatible clients


### PR DESCRIPTION
Added a new use case: **Agent Email Infrastructure**

Give your OpenClaw agent its own email address — no human signup, no API keys, no dashboard. Uses the [LobsterMail skill](https://clawhub.ai/samuelchenardlovesboards/lobstermail-agent-email) from ClawHub.

Includes:
- Use case description and problem statement
- Quick start with `clawhub install`
- Links to SDK, MCP server, and website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Agent Email Infrastructure documentation enabling autonomous agents to manage email independently using the LobsterMail skill
  * Features quick-start setup instructions and built-in security protections (prompt-injection safety, SPF/DKIM/DMARC authentication standards)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->