### PR TITLE
Add use case: HF Papers Research Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Semantic Memory Search](usecases/semantic-memory-search.md) | Add vector-powered semantic search to your OpenClaw markdown memory files with hybrid retrieval and auto-sync. |
 | [arXiv Paper Reader](usecases/arxiv-paper-reader.md) | Read and analyze arXiv papers conversationally — fetch by ID, browse sections, compare abstracts, and get AI summaries. |
 | [LaTeX Paper Writing](usecases/latex-paper-writing.md) | Write and compile LaTeX papers conversationally with instant PDF preview — no local TeX installation needed. |
+| [HF Papers Research Discovery](usecases/hf-papers-research-discovery.md) | Discover trending ML papers on Hugging Face, triage by upvotes, and deep-read via arXiv — all conversationally. |
 
 ## Finance & Trading
 

--- a/usecases/hf-papers-research-discovery.md
+++ b/usecases/hf-papers-research-discovery.md
@@ -8,12 +8,12 @@ This workflow combines two skills to create a full research discovery pipeline:
 - Search papers by keyword to find relevant work on any topic
 - Get full paper metadata: abstract, authors, GitHub repos, community upvotes, AI-generated summaries
 - Read community discussion and comments on any paper
-- Deep-read the full LaTeX source of any paper via its arXiv ID (using arxiv-reader)
+- Deep-read the full LaTeX source of any paper via its arXiv ID (using arxiv-source)
 
 ## Skills you Need
 
 - [hf-papers](https://github.com/openclaw/skills/tree/main/skills/willamhou/hf-papers) skill (4 tools: `hf_daily_papers`, `hf_search_papers`, `hf_paper_detail`, `hf_paper_comments`)
-- [arxiv-reader](https://github.com/openclaw/skills/tree/main/skills/willamhou/arxiv-source) skill (3 tools: `arxiv_fetch`, `arxiv_sections`, `arxiv_abstract`) — for full paper text
+- [arxiv-source](https://github.com/openclaw/skills/tree/main/skills/willamhou/arxiv-source) skill (3 tools: `arxiv_fetch`, `arxiv_sections`, `arxiv_abstract`) — for full paper text
 
 No Docker or authentication required — both skills use public APIs with local caching.
 
@@ -42,7 +42,7 @@ I want to stay on top of ML research. Here's my daily workflow:
    - Ask if I want a deep read
 
 4. For deep reads:
-   - Fetch the full paper via arxiv-reader
+   - Fetch the full paper via arxiv-source
    - Summarize key contributions, methodology, and results
    - Note any linked code repos I should check out
 

--- a/usecases/hf-papers-research-discovery.md
+++ b/usecases/hf-papers-research-discovery.md
@@ -1,0 +1,52 @@
+# HF Papers Research Discovery
+
+Keeping up with ML research means refreshing Hugging Face Papers daily, scanning dozens of titles, clicking into each one for the abstract, and manually cross-referencing GitHub repos. You want a conversational way to discover, triage, and deep-read trending papers without leaving your workspace.
+
+This workflow combines two skills to create a full research discovery pipeline:
+
+- Browse today's trending papers on Hugging Face — sorted by upvotes or date
+- Search papers by keyword to find relevant work on any topic
+- Get full paper metadata: abstract, authors, GitHub repos, community upvotes, AI-generated summaries
+- Read community discussion and comments on any paper
+- Deep-read the full LaTeX source of any paper via its arXiv ID (using arxiv-reader)
+
+## Skills you Need
+
+- [hf-papers](https://github.com/openclaw/skills/tree/main/skills/willamhou/hf-papers) skill (4 tools: `hf_daily_papers`, `hf_search_papers`, `hf_paper_detail`, `hf_paper_comments`)
+- [arxiv-reader](https://github.com/openclaw/skills/tree/main/skills/willamhou/arxiv-source) skill (3 tools: `arxiv_fetch`, `arxiv_sections`, `arxiv_abstract`) — for full paper text
+
+No Docker or authentication required — both skills use public APIs with local caching.
+
+## How to Set it Up
+
+1. Install both skills:
+```bash
+clawhub install hf-papers
+clawhub install arxiv-source
+```
+
+2. Prompt OpenClaw with your research workflow:
+```text
+I want to stay on top of ML research. Here's my daily workflow:
+
+1. Every morning, show me the top 10 trending papers on Hugging Face (sorted by upvotes)
+   - For each paper, show: title, upvotes, GitHub repo (if any), and 1-line AI summary
+
+2. When I say "search [topic]":
+   - Search HF Papers and show the most relevant results
+   - Highlight papers with linked GitHub repos or high upvote counts
+
+3. When I pick a paper (by ID):
+   - Show the full abstract, authors, and linked resources
+   - Show community comments if any
+   - Ask if I want a deep read
+
+4. For deep reads:
+   - Fetch the full paper via arxiv-reader
+   - Summarize key contributions, methodology, and results
+   - Note any linked code repos I should check out
+
+Keep a running list of papers I've reviewed today with one-line takeaways.
+```
+
+3. Try it: "What's trending on Hugging Face Papers today?"


### PR DESCRIPTION
## Summary

Adds a new use case for discovering and reading ML research papers using two OpenClaw skills:

- **hf-papers** — browse trending Hugging Face Papers, search by keyword, get metadata and comments
- **arxiv-reader** — deep-read full paper text via arXiv LaTeX source

The workflow: discover trending papers → triage by upvotes/topic → deep-read the interesting ones — all conversationally.

## Skills referenced

- `hf-papers`: https://clawhub.ai/willamhou/hf-papers
- `arxiv-source`: https://clawhub.ai/willamhou/arxiv-source

Both skills are published on ClaWHub and synced to the official OpenClaw skills repo:
- https://github.com/openclaw/skills/tree/main/skills/willamhou/hf-papers
- https://github.com/openclaw/skills/tree/main/skills/willamhou/arxiv-source

## Category

Research & Learning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new use-case guide "HF Papers Research Discovery" describing a two-skill workflow to browse trending papers, search by keyword, retrieve metadata (abstracts, authors, repos, upvotes), read discussions, and perform deep reads via arXiv IDs; includes setup steps and example prompts.
  * Fixed duplication: the same use-case entry was inserted twice in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->