### PR TITLE
Add use case: OpenClaw cost estimation before running agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 
 | Use Case | Description |
 |----------|------------|
-| [Cost Estimation](https://calculator.guardclaw.dev/) | Estimate OpenClaw setup cost before running agents to avoid unexpected spend |
+| [Cost Estimation](usecases/openclaw-cost-estimation.md) | Estimate OpenClaw setup cost before running agents to avoid unexpected spend |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
 
+## Cost & Optimization
+
+| Use Case | Description |
+|----------|------------|
+| [Cost Estimation](https://calculator.guardclaw.dev/) | Estimate OpenClaw setup cost before running agents to avoid unexpected spend |
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/usecases/openclaw-cost-estimation.md
+++ b/usecases/openclaw-cost-estimation.md
@@ -1,0 +1,52 @@
+# OpenClaw Cost Estimation Before Running Agents
+
+## Pain Point
+
+OpenClaw users often run agents without knowing how much it will cost.
+
+This leads to:
+- budgets draining unexpectedly
+- heartbeats consuming tokens silently
+- fallback models increasing spend without visibility
+
+Most users only realize the cost after it's too late.
+
+---
+
+## What It Does
+
+This use case helps you estimate your OpenClaw setup cost before running agents.
+
+By defining your:
+- model usage (primary + fallback)
+- heartbeat interval
+- message volume
+- multi-agent setup
+
+You can calculate expected daily, monthly, and yearly spend.
+
+---
+
+## Prompts
+
+Example config inputs:
+
+- Primary model: claude-sonnet
+- Fallback model: claude-haiku
+- Messages/day: 50
+- Heartbeat interval: 30 minutes
+- Tokens per message: 800 input / 1200 output
+
+---
+
+## Skills Needed
+
+- Basic OpenClaw configuration
+- Understanding of models and token usage
+- Optional: multi-agent setup
+
+---
+
+## Related Links
+
+- OpenClaw Setup Cost Calculator: https://calculator.guardclaw.dev/


### PR DESCRIPTION
Adds a practical use case for estimating OpenClaw setup cost to prevent unexpected token spend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Cost & Optimization" section with a Cost Estimation use case to help estimate expected daily/monthly/yearly spend before running agents.
  * Includes required inputs (model choices, fallback model, message volume, heartbeat interval, multi-agent considerations), a sample configuration, prompts/example inputs, and a link to a cost calculator tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->