### PR TITLE
Add use case: Running OpenClaw bots in Docker sandboxes with ClawPier

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
-| [Sandboxed Multi-Bot Management](usecases/sandboxed-multi-bot-management.md) | Run multiple OpenClaw bots in isolated Docker containers with a native GUI — sandboxed by default, no CLI required. [ClawPier](https://github.com/SebastianElvis/clawpier) |
-| [Sandboxed Multi-Bot Management](usecases/sandboxed-multi-bot-management.md) | Run multiple OpenClaw bots in isolated Docker containers with a native GUI — sandboxed by default, no CLI required. [ClawPier](https://github.com/SebastianElvis/clawpier) |
+| [Running Bots in Docker Sandboxes](usecases/sandboxed-multi-bot-management.md) | Manage multiple OpenClaw bots via a native GUI, with each bot isolated in its own Docker container — network disabled by default. [ClawPier](https://github.com/SebastianElvis/clawpier) |
+| [Running Bots in Docker Sandboxes](usecases/sandboxed-multi-bot-management.md) | Manage multiple OpenClaw bots via a native GUI, with each bot isolated in its own Docker container — network disabled by default. [ClawPier](https://github.com/SebastianElvis/clawpier) |
 
 ## Productivity
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
 | [Running Bots in Docker Sandboxes](usecases/sandboxed-multi-bot-management.md) | Manage multiple OpenClaw bots via a native GUI, with each bot isolated in its own Docker container — network disabled by default. [ClawPier](https://github.com/SebastianElvis/clawpier) |
-| [Running Bots in Docker Sandboxes](usecases/sandboxed-multi-bot-management.md) | Manage multiple OpenClaw bots via a native GUI, with each bot isolated in its own Docker container — network disabled by default. [ClawPier](https://github.com/SebastianElvis/clawpier) |
 
 ## Productivity
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
+| [Sandboxed Multi-Bot Management](usecases/sandboxed-multi-bot-management.md) | Run multiple OpenClaw bots in isolated Docker containers with a native GUI — sandboxed by default, no CLI required. [ClawPier](https://github.com/SebastianElvis/clawpier) |
+| [Sandboxed Multi-Bot Management](usecases/sandboxed-multi-bot-management.md) | Run multiple OpenClaw bots in isolated Docker containers with a native GUI — sandboxed by default, no CLI required. [ClawPier](https://github.com/SebastianElvis/clawpier) |
 
 ## Productivity
 

--- a/usecases/sandboxed-multi-bot-management.md
+++ b/usecases/sandboxed-multi-bot-management.md
@@ -1,0 +1,50 @@
+# Sandboxed Multi-Bot Management with ClawPier
+
+## Overview
+
+Run multiple OpenClaw instances in isolated Docker containers with a native desktop GUI — no terminal required. Each bot is sandboxed with `--network none` by default, so a prompt injection can't reach your host machine.
+
+## Why?
+
+OpenClaw has OS-level access to your email, calendars, files, and messaging platforms. Running it directly on your host means a prompt injection gives an attacker your machine. ClawPier fixes this by running every bot inside a Docker container with network isolation by default.
+
+## Setup
+
+### Install ClawPier
+
+**macOS (Homebrew):**
+```bash
+brew tap SebastianElvis/clawpier
+brew install --cask clawpier
+```
+
+**Or download** from [GitHub Releases](https://github.com/SebastianElvis/clawpier/releases) — available for macOS (signed & notarized), Linux (.AppImage, .deb), and Windows (.exe, .msi).
+
+### Prerequisites
+
+- Docker must be installed and running
+- ClawPier will prompt you to pull the OpenClaw image on first launch
+
+## How It Works
+
+1. **Create a bot** — give it a name and optionally set a workspace path
+2. **Configure** — set environment variables, resource limits (CPU/memory), network mode, and port mappings from the GUI
+3. **Start** — the bot runs in a Docker container with `--network none` by default
+4. **Interact** — use the built-in chat, terminal, log viewer, file browser, or skill browser
+5. **Monitor** — live CPU, memory, and network I/O stats per bot
+
+### Key Security Features
+
+- **Network isolation** — containers start with no network access; enable bridge/host per bot only when needed
+- **Resource limits** — set CPU and memory caps from the GUI
+- **One-click stop** — kill a misbehaving agent instantly
+- **Port conflict detection** — warns if a host port is already in use before you start
+
+### Skill Management
+
+Browse 50+ bundled skills, search the ClawHub registry, and install/uninstall skills with one click — all from a visual skill browser inside ClawPier.
+
+## Links
+
+- [GitHub](https://github.com/SebastianElvis/clawpier)
+- [Demo Video](https://github.com/SebastianElvis/clawpier/releases/download/v0.3.0/clawpier-demo.mov)

--- a/usecases/sandboxed-multi-bot-management.md
+++ b/usecases/sandboxed-multi-bot-management.md
@@ -1,12 +1,12 @@
-# Sandboxed Multi-Bot Management with ClawPier
+# Running Multiple OpenClaw Bots in Docker Sandboxes
 
 ## Overview
 
-Run multiple OpenClaw instances in isolated Docker containers with a native desktop GUI — no terminal required. Each bot is sandboxed with `--network none` by default, so a prompt injection can't reach your host machine.
+Manage multiple OpenClaw instances through a native desktop GUI, with each bot running in its own isolated Docker container. Containers start with `--network none` by default — network access is opt-in per bot.
 
 ## Why?
 
-OpenClaw has OS-level access to your email, calendars, files, and messaging platforms. Running it directly on your host means a prompt injection gives an attacker your machine. ClawPier fixes this by running every bot inside a Docker container with network isolation by default.
+OpenClaw has OS-level access to your email, calendars, files, and messaging platforms. Running it directly on your host means a prompt injection gives an attacker your machine. ClawPier isolates each bot inside a Docker container with network disabled by default, so a compromised agent can't reach your host or the internet.
 
 ## Setup
 
@@ -29,15 +29,15 @@ brew install --cask clawpier
 
 1. **Create a bot** — give it a name and optionally set a workspace path
 2. **Configure** — set environment variables, resource limits (CPU/memory), network mode, and port mappings from the GUI
-3. **Start** — the bot runs in a Docker container with `--network none` by default
+3. **Start** — the bot runs in its own Docker container, isolated from your host by default
 4. **Interact** — use the built-in chat, terminal, log viewer, file browser, or skill browser
 5. **Monitor** — live CPU, memory, and network I/O stats per bot
 
 ### Key Security Features
 
-- **Network isolation** — containers start with no network access; enable bridge/host per bot only when needed
-- **Resource limits** — set CPU and memory caps from the GUI
-- **One-click stop** — kill a misbehaving agent instantly
+- **Network isolation** — each bot's container starts with no network access; enable bridge/host only when needed
+- **Resource limits** — set CPU and memory caps per bot from the GUI
+- **One-click stop** — kill a misbehaving agent instantly; your host is never at risk
 - **Port conflict detection** — warns if a host port is already in use before you start
 
 ### Skill Management


### PR DESCRIPTION
## Use Case: Sandboxed Multi-Bot Management

Adds a new use case under **Infrastructure & DevOps** for running multiple OpenClaw instances in isolated Docker containers via [ClawPier](https://github.com/SebastianElvis/clawpier).

**Why this matters:** OpenClaw has OS-level access to email, calendars, files, and messaging. A prompt injection gives an attacker your machine. ClawPier runs every bot in a Docker container with `--network none` by default.

**What it covers:**
- Installing ClawPier via Homebrew or direct download (macOS/Linux/Windows)
- Creating, configuring, and monitoring bots from the GUI
- Security model: network isolation, resource limits, one-click stop
- Skill management via the built-in ClawHub browser

**Files:**
- `usecases/sandboxed-multi-bot-management.md` — detailed use case writeup
- `README.md` — added one row to the Infrastructure & DevOps table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for Sandboxed Multi‑Bot Management with ClawPier — macOS installation options, setup workflow, per‑bot Docker isolation with opt‑in networking, resource limits, host port conflict checks, one‑click stop for misbehaving agents, and runtime CPU/memory/network monitoring.
  * Added guidance on visual skill management (browse, search, install/uninstall), GUI interaction tools (chat/terminal/logs/file browser/skill browser), and a demo/link to the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->