### PR TITLE
Add XVARY Stock Research (Claude Code skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
 
+## XVARY Stock Research
+
+- [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
+
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adds [xvary-research/claude-code-stock-analysis-skill](https://github.com/xvary-research/claude-code-stock-analysis-skill) — MIT, public SEC EDGAR + market data workflow (`/analyze`, `/score`, `/compare`) for Claude Code / compatible agents.

Inserted as a short README section before Contributing/License where possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "XVARY Stock Research" section to README with details about available commands (`/analyze`, `/score`, `/compare`) and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->