### PR TITLE
Add Product Manager Skills to Research & Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [AI Earnings Tracker](usecases/earnings-tracker.md) | Track tech/AI earnings reports with automated previews, alerts, and detailed summaries. |
 | [Personal Knowledge Base (RAG)](usecases/knowledge-base-rag.md) | Build a searchable knowledge base by dropping URLs, tweets, and articles into chat. |
 | [Market Research & Product Factory](usecases/market-research-product-factory.md) | Mine Reddit and X for real pain points using the Last 30 Days skill, then have OpenClaw build MVPs that solve them. |
+| [Product Manager Skills](https://github.com/Digidai/product-manager-skills) | Senior PM agent for Claude Code — 6 knowledge domains, 30+ frameworks, 32 SaaS metrics with formulas, 12 templates, and anti-pattern detection. Pure Markdown, no scripts. |
 | [Pre-Build Idea Validator](usecases/pre-build-idea-validator.md) | Automatically scan GitHub, HN, npm, PyPI, and Product Hunt before building anything new — stop if the space is crowded, proceed if it's open. |
 | [Semantic Memory Search](usecases/semantic-memory-search.md) | Add vector-powered semantic search to your OpenClaw markdown memory files with hybrid retrieval and auto-sync. |
 | [arXiv Paper Reader](usecases/arxiv-paper-reader.md) | Read and analyze arXiv papers conversationally — fetch by ID, browse sections, compare abstracts, and get AI summaries. |


### PR DESCRIPTION
Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Research & Learning section.

It's a senior PM agent for Claude Code covering 6 knowledge domains, 30+ frameworks, 32 SaaS metrics with formulas, 12 ready-to-use templates, and anti-pattern detection. Pure Markdown, no scripts, MIT-0 license.

Fits well alongside Market Research & Product Factory and Pre-Build Idea Validator since it covers the product strategy and metrics side of building products.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Product Manager Skills" resource to the Research & Learning section, providing reference materials and frameworks for product management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->