### PR TITLE
Add use case: Auto WeChat Official Account Publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
 | [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | Automatically aggregate and deliver quality-scored tech news from 109+ sources (RSS, Twitter/X, GitHub, web search) via natural language. |
 | [X/Twitter Automation](usecases/x-twitter-automation.md) | Post tweets, reply, like, retweet, follow, DM, search, extract data, run giveaways, and monitor accounts — all from chat via the TweetClaw plugin. |
+| [Auto WeChat Official Account Publishing](usecases/wechat-auto-publish.md) | Publish markdown from Feishu/Telegram chat to WeChat Official Account with QR login + confirm flow via OpenClaw and Gateway. |
 
 ## Creative & Building
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
 | [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | Automatically aggregate and deliver quality-scored tech news from 109+ sources (RSS, Twitter/X, GitHub, web search) via natural language. |
 | [X/Twitter Automation](usecases/x-twitter-automation.md) | Post tweets, reply, like, retweet, follow, DM, search, extract data, run giveaways, and monitor accounts — all from chat via the TweetClaw plugin. |
-| [Auto WeChat Official Account Publishing](usecases/wechat-auto-publish.md) | Publish markdown from Feishu/Telegram chat to WeChat Official Account with QR login + confirm flow via OpenClaw and Gateway. |
+| [Auto WeChat Official Account Publishing](usecases/wechat-auto-publish.md) | Publish markdown from Feishu/Telegram/Web UI to WeChat Official Account with QR login + confirm flow via OpenClaw and Gateway. |
 
 ## Creative & Building
 

--- a/usecases/wechat-auto-publish.md
+++ b/usecases/wechat-auto-publish.md
@@ -1,0 +1,49 @@
+# Auto WeChat Official Account Publishing
+
+## Pain Point
+
+Publishing a long markdown article to WeChat Official Account is repetitive and error-prone when done manually in the browser every time.
+
+## What It Does
+
+This setup lets OpenClaw publish markdown from chat channels (Feishu/Telegram/Web UI) to WeChat via a `publish_wechat` skill and a Gateway service.
+
+- OpenClaw sends raw markdown to Gateway (no markdown-to-HTML conversion in OpenClaw)
+- Gateway creates a publish task and returns status
+- If login is required, OpenClaw shows a QR image for WeChat login
+- User confirms login and OpenClaw continues the publish flow
+
+## Prompts
+
+Natural language trigger:
+
+```text
+帮我把这篇文章发到微信公众号上去
+```
+
+Skill command examples:
+
+```text
+/publish_wechat
+/publish_wechat status <task_id>
+/publish_wechat confirm <task_id>
+/publish_wechat relogin
+```
+
+Example operator flow:
+
+1. Paste markdown article in the chat
+2. Send `帮我把这篇文章发到微信公众号上去` (or `/publish_wechat`)
+3. If status is `waiting_login`, scan the QR code image
+4. Send `/publish_wechat confirm <task_id>`
+5. Use `/publish_wechat status <task_id>` to check final status
+
+## Skills Needed
+
+- Custom OpenClaw skill: `publish_wechat`
+  - Supports: publish, status, confirm, relogin
+
+## Related Links
+
+- OpenClaw: https://github.com/openclaw/openclaw
+- WeChat publish gateway implementation: https://github.com/xu75/openclaw-wechat-gateway


### PR DESCRIPTION
Summary:
- add a new tested use case: auto publishing markdown articles to WeChat Official Account from OpenClaw chat channels
- document natural language trigger and command flow (/publish_wechat, status, confirm, relogin)
- add the use case entry to the Social Media section in README

Notes:
- focuses on real, tested workflow (Feishu/Telegram + QR login + confirm flow)
- OpenClaw sends raw markdown; content processing remains in gateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Social Media" use-case for Auto WeChat Official Account Publishing, describing an end-to-end workflow to publish long Markdown articles from Feishu/Telegram/Web UI to WeChat with QR code login and user confirmation.
  * Includes operator steps, publish task lifecycle and status monitoring, and example user commands for publishing, checking status, confirming, and relogin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->