### PR TITLE
Add use case: Daily Business Briefing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-43-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-44-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | Name | Description |
 |------|-------------|
 | [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
+| [Daily Business Briefing](usecases/daily-business-briefing.md) | Pull revenue, subscribers, churn, and order data from Stripe/Shopify/Gumroad every morning into a single briefing message. |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-42-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-43-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)
@@ -97,7 +97,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | Name | Description |
 |------|-------------|
 | [Polymarket Autopilot](usecases/polymarket-autopilot.md) | Automated paper trading on prediction markets with backtesting, strategy analysis, and daily performance reports. |
-| [Daily Business Briefing](usecases/daily-business-briefing.md) | Pull revenue, subscribers, churn, and order data from Stripe/Shopify/Gumroad every morning into a single briefing message. |
+| [Daily Business Briefing](usecases/daily-business-briefing.md) | Pull revenue, subscribers, churn, and order data from Stripe, Shopify, Lemon Squeezy, or Gumroad every morning into a single briefing message. |
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Daily Business Briefing

Pulls revenue, subscriber, churn, and order data from Stripe, Shopify, Lemon Squeezy, or Gumroad every morning and delivers a clean briefing via iMessage, Slack, Telegram, or email.

**Why it's different from Custom Morning Brief:** The existing morning brief is general (news, tasks, content). This is specifically business metrics from payment/commerce APIs with month-to-date pacing and anomaly alerts.

**Verified:** Built and tested with real Stripe and Shopify adapter connections. Published on ClawHub with one paying customer. Demo command works with zero config for evaluation.

**Skill link:** [northstar on ClawHub](https://clawhub.ai/daveglaser0823/northstar)

Added to the Finance & Trading category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Daily Business Briefing" use case showing how to combine revenue, subscribers, churn, and orders from multiple platforms into a single daily briefing.
  * Updated the Use Cases badge count from 42 to 44 to reflect the new example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->