### PR TITLE
fix(pre-build-idea-validator): add working CLI wrapper for OpenClaw

### DIFF
--- a/skills/pre-build-idea-validator/SKILL.md
+++ b/skills/pre-build-idea-validator/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: pre-build-idea-validator
+description: Use when starting any new project, feature, or tool before writing any code, or when the user shares a GitHub repo URL and wants to understand its idea or market position
+---
+
+# Pre-Build Idea Validator
+
+Before starting anything new, check whether it already exists. Scans GitHub and Hacker News and returns a `reality_signal` score (0–100).
+
+## Setup
+
+Install the `idea-reality-mcp` Python package (required):
+
+```bash
+pip install idea-reality-mcp
+```
+
+Place `idea-check.mjs` (included in this skill directory) alongside this `SKILL.md`.
+
+## When to Use
+
+- Before any new project, feature, CLI tool, or library
+- When you want to know if an idea is original
+- Before a hackathon: batch-validate multiple ideas and pick the lowest score
+- When the user shares a GitHub repo URL and asks what it does, whether it's worth building, or how crowded the space is
+
+## How to Use
+
+### New idea
+```bash
+node {baseDir}/idea-check "describe the idea here"
+```
+
+For a deeper scan (all 5 sources — GitHub, HN, npm, PyPI, Product Hunt):
+```bash
+node {baseDir}/idea-check "describe the idea here" --depth deep
+```
+
+### GitHub repo URL
+1. Fetch the repo README to extract a 1-sentence description
+2. Run `idea-check` with that description as the query
+3. Report the `reality_signal` alongside what the repo does
+
+## Decision Rules
+
+| reality_signal | Action |
+|---|---|
+| > 70 | **STOP.** Report top 3 competitors with star counts. Ask whether to proceed, pivot, or abandon. |
+| 30–70 | Show results + pivot hints. Suggest a niche angle existing projects don't cover. |
+| < 30 | Proceed. Mention the space is open. |
+
+Always show the score and top competitors before writing any code. Do NOT write `idea-check.mjs` yourself — it already exists in `{baseDir}`.
+
+## Example Output
+
+```
+reality_signal: 59/100 (MEDIUM competition)
+
+Top competitors:
+  1. bruno-smith/Automated_Tee_Time_Booking — 11 stars
+     Python code to book tee times through selenium
+  2. niallhodgen/tee-time-booker — 4 stars
+     An experimental program to automate tee time booking
+
+Pivot hints:
+  • Moderate competition exists. Focus on a specific use case current solutions handle poorly.
+  • Validate with potential users before building.
+```

--- a/skills/pre-build-idea-validator/idea-check.mjs
+++ b/skills/pre-build-idea-validator/idea-check.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * idea-check — CLI wrapper for idea-reality-mcp
+ *
+ * Bridges OpenClaw's exec tool to the idea-reality-mcp MCP server over stdio.
+ * Finds the installed binary automatically, falling back to uvx.
+ *
+ * Usage:
+ *   node idea-check "your idea description" [--depth quick|deep]
+ *
+ * Setup (pick one):
+ *   pip install idea-reality-mcp   ← recommended, fastest
+ *   uvx idea-reality-mcp           ← auto-downloads on first run, slower
+ */
+import { spawn, execSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { existsSync } from 'node:fs';
+
+const { values, positionals } = parseArgs({
+  options: {
+    depth: { type: 'string', default: 'quick' },
+    help: { type: 'boolean', short: 'h', default: false },
+  },
+  allowPositionals: true,
+  strict: false,
+});
+
+if (values.help || positionals.length === 0) {
+  console.log('Usage: node idea-check "your idea" [--depth quick|deep]');
+  process.exit(0);
+}
+
+const ideaText = positionals.join(' ');
+const depth = values.depth;
+
+function findBinary() {
+  // 1. System PATH
+  try {
+    const p = execSync('which idea-reality-mcp 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (p && existsSync(p)) return [p, []];
+  } catch {}
+  // 2. Common install locations
+  const candidates = [
+    `${process.env.HOME}/.local/bin/idea-reality-mcp`,
+    '/usr/local/bin/idea-reality-mcp',
+    '/usr/bin/idea-reality-mcp',
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return [c, []];
+  }
+  // 3. Fallback: uvx (slower on first run — downloads packages)
+  return ['uvx', ['idea-reality-mcp']];
+}
+
+function formatOutput(d) {
+  const signal = d.reality_signal;
+  const level = signal > 70 ? 'HIGH' : signal >= 30 ? 'MEDIUM' : 'LOW';
+  const lines = [`reality_signal: ${signal}/100 (${level} competition)`, ''];
+  if (d.top_similars?.length) {
+    lines.push('Top competitors:');
+    d.top_similars.slice(0, 3).forEach((s, i) => {
+      lines.push(`  ${i + 1}. ${s.name} — ${s.stars} stars`);
+      if (s.description) lines.push(`     ${s.description}`);
+    });
+    lines.push('');
+  }
+  if (d.pivot_hints?.length) {
+    lines.push('Pivot hints:');
+    d.pivot_hints.forEach(h => lines.push(`  • ${h}`));
+  }
+  return lines.join('\n');
+}
+
+const [cmd, args] = findBinary();
+const proc = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+let buffer = '';
+let initialized = false;
+let done = false;
+
+proc.stdout.on('data', chunk => {
+  buffer += chunk.toString();
+  const lines = buffer.split('\n');
+  buffer = lines.pop();
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+
+    if (msg.id === 1 && msg.result?.serverInfo && !initialized) {
+      initialized = true;
+      proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+      proc.stdin.write(JSON.stringify({
+        jsonrpc: '2.0', id: 2, method: 'tools/call',
+        params: { name: 'idea_check', arguments: { idea_text: ideaText, depth } },
+      }) + '\n');
+    }
+
+    if (msg.id === 2 && !done) {
+      done = true;
+      const text = msg.result?.content?.map(c => c.text ?? '').join('\n').trim();
+      try { console.log(formatOutput(JSON.parse(text))); }
+      catch { console.log(text); }
+      proc.kill(); process.exit(0);
+    }
+
+    if (msg.error && !done) {
+      done = true;
+      console.error('Error:', msg.error.message);
+      proc.kill(); process.exit(1);
+    }
+  }
+});
+
+proc.stderr.on('data', d => {
+  const s = d.toString();
+  const noise = ['Downloading', 'Installed', 'Downloaded', 'INFO', 'FastMCP', 'fastmcp', 'Starting', 'gofastmcp'];
+  if (!noise.some(n => s.includes(n))) process.stderr.write(s);
+});
+
+proc.on('error', err => {
+  console.error('Failed to start idea-reality-mcp:', err.message);
+  console.error('Install it with: pip install idea-reality-mcp');
+  process.exit(1);
+});
+proc.on('close', code => {
+  if (!done) { console.error('Process exited early (code ' + code + ')'); process.exit(1); }
+});
+
+proc.stdin.write(JSON.stringify({
+  jsonrpc: '2.0', id: 1, method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'idea-check-cli', version: '1.0' } },
+}) + '\n');
+
+setTimeout(() => { if (!done) { console.error('Timeout'); proc.kill(); process.exit(1); } }, 60000);

--- a/usecases/pre-build-idea-validator.md
+++ b/usecases/pre-build-idea-validator.md
@@ -4,7 +4,7 @@ Before OpenClaw starts building anything new, it automatically checks whether th
 
 ## What It Does
 
-- Scans 5 real data sources (GitHub, Hacker News, npm, PyPI, Product Hunt) before any code is written
+- Scans real data sources (GitHub, Hacker News, npm, PyPI, Product Hunt) before any code is written
 - Returns a `reality_signal` score (0-100) indicating how crowded the space is
 - Shows top competitors with star counts and descriptions
 - Suggests pivot directions when the space is saturated
@@ -16,28 +16,27 @@ You tell your agent "build me an AI code review tool" and it happily spends 6 ho
 
 ## Skills You Need
 
-- [idea-reality-mcp](https://github.com/mnemox-ai/idea-reality-mcp) — MCP server that scans real data sources and returns a competition score
+- [idea-reality-mcp](https://github.com/mnemox-ai/idea-reality-mcp) — Python package that scans real data sources and returns a competition score
 
 ## How to Set It Up
 
-1. Install idea-reality-mcp:
+> **Note:** OpenClaw does not support MCP servers via config. Instead, use the included CLI wrapper (`idea-check.mjs`) which speaks the MCP stdio protocol directly and can be called via OpenClaw's exec tool.
+
+1. Install the Python package:
 
 ```bash
-uvx idea-reality-mcp
+pip install idea-reality-mcp
 ```
 
-2. Add the MCP server to your OpenClaw config:
+2. Copy the skill files into your OpenClaw skills directory:
 
-```json
-{
-  "mcpServers": {
-    "idea-reality": {
-      "command": "uvx",
-      "args": ["idea-reality-mcp"]
-    }
-  }
-}
 ```
+~/.openclaw/skills/pre-build-idea-validator/
+  SKILL.md          ← tells OpenClaw when and how to use this skill
+  idea-check.mjs    ← CLI wrapper (Node.js, no extra deps)
+```
+
+The skill files are in the [`skills/pre-build-idea-validator/`](../skills/pre-build-idea-validator/) folder of this repo.
 
 3. Add this to your OpenClaw agent instructions:
 
@@ -58,9 +57,9 @@ Rules:
 
 **You:** "Build me a CLI tool for AI code review"
 
-OpenClaw runs `idea_check("AI code review tool")` and responds:
+OpenClaw runs `node {baseDir}/idea-check "AI code review tool"` and responds:
 
-> **reality_signal: 90/100 (very high)**
+> **reality_signal: 90/100 (HIGH competition)**
 >
 > Top competitors:
 > 1. Gitea — 53,940 stars
@@ -78,7 +77,7 @@ OpenClaw runs `idea_check("AI code review tool")` and responds:
 
 **You:** "What about an MCP server for pre-build idea validation?"
 
-> **reality_signal: 8/100 (very low)**
+> **reality_signal: 8/100 (LOW competition)**
 >
 > 0 direct competitors found on PyPI or npm. GitHub has some tangentially related repos but none solve this exact problem.
 >
@@ -86,9 +85,9 @@ OpenClaw runs `idea_check("AI code review tool")` and responds:
 
 ## Variations
 
-- **Deep mode for serious decisions**: Use `depth="deep"` to scan all 5 sources in parallel (GitHub + HN + npm + PyPI + Product Hunt) for major project decisions.
+- **Deep mode for serious decisions**: Use `--depth deep` to scan all 5 sources in parallel (GitHub + HN + npm + PyPI + Product Hunt).
 - **Batch validation**: Before a hackathon, give OpenClaw a list of 10 ideas and have it rank them by `reality_signal` — lowest score = most original opportunity.
-- **Web demo first**: Try without installing at [mnemox.ai/check](https://mnemox.ai/check) to see if the workflow fits your needs.
+- **Web demo first**: Try without installing at [mnemox.ai/check](https://mnemox.ai/check).
 
 ## Key Insights
 
@@ -100,5 +99,5 @@ OpenClaw runs `idea_check("AI code review tool")` and responds:
 ## Related Links
 
 - [idea-reality-mcp GitHub](https://github.com/mnemox-ai/idea-reality-mcp)
-- [Web demo](https://mnemox.ai/check) (try without installing)
+- [Web demo](https://mnemox.ai/check)
 - [PyPI](https://pypi.org/project/idea-reality-mcp/)


### PR DESCRIPTION
OpenClaw does not support MCP servers via mcpServers config — the original setup instructions cause the gateway to crash with "Unrecognized key: mcpServers".

This PR adds a Node.js CLI wrapper (idea-check.mjs) that speaks the MCP stdio protocol directly to idea-reality-mcp, making it callable via OpenClaw's exec tool with no config changes needed.

Changes:
- skills/pre-build-idea-validator/idea-check.mjs: portable CLI wrapper, auto-discovers the installed binary, pretty-prints results
- skills/pre-build-idea-validator/SKILL.md: ready-to-use skill file using {baseDir} template variable
- usecases/pre-build-idea-validator.md: updated setup instructions to use the CLI wrapper instead of the broken mcpServers approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Updated setup instructions for the pre-build-idea-validator tool
  * Changed installation and configuration approach for improved accessibility
  * Updated command execution syntax and output format labels for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->