### PR TITLE
Add use case: Autonomous Deal Closer (multi-MCP pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Event Guest Confirmation](usecases/event-guest-confirmation.md) | Call a list of event guests one-by-one to confirm attendance, collect notes, and compile a summary — fully automated via AI voice calls. |
 | [Phone Call Notifications](usecases/phone-call-notifications.md) | Turn your agent's alerts into real phone calls — morning briefings, price drops, urgent emails — with two-way conversation. |
 | [Local CRM Framework](usecases/local-crm-framework.md) | Turn OpenClaw into a fully local CRM and sales automation platform with `npx denchclaw` — DuckDB, browser automation, multi-view UI, and natural language queries. |
+| [Autonomous Deal Closer](usecases/autonomous-deal-closer.md) | Chain Firecrawl + email + Cal.com + Signbee MCP servers into one pipeline that researches prospects, sends outreach, books meetings, drafts contracts, and collects signatures. |
 
 ## Research & Learning
 

--- a/usecases/autonomous-deal-closer.md
+++ b/usecases/autonomous-deal-closer.md
@@ -1,0 +1,97 @@
+# Autonomous Deal Closer
+
+You find leads, qualify them, send outreach, book meetings, draft contracts, and get signatures. That's 6 tools across 3 hours of manual work per deal. OpenClaw can run this entire pipeline while you sleep.
+
+## Pain Point
+
+Closing a B2B deal requires coordinating across research, email, calendaring, and document signing tools. Each step depends on the previous one, and context gets lost between tools. You end up copy-pasting between tabs for hours.
+
+## What It Does
+
+- **Lead research**: Uses Firecrawl MCP to scrape a prospect's website and extract team info, product details, and contact data
+- **Outreach drafting**: Generates a personalised cold email using the scraped context
+- **Calendar booking**: Uses Cal.com to find mutual availability and include a booking link in the outreach
+- **Contract generation**: Drafts a services agreement in markdown using deal-specific terms from the conversation
+- **E-signing**: Sends the contract for two-party signing with SHA-256 certificates via Signbee MCP
+- **Status tracking**: Updates a local `DEALS.yaml` file with pipeline status after each step
+
+## Skills Needed
+
+- `mcp__firecrawl__scrape` — prospect research and data extraction
+- `mcp__gmail__send` or any email MCP — outreach delivery
+- `mcp__calcom__create_booking` — meeting scheduling
+- `mcp__signbee__send_document` — contract e-signing
+- File system access for DEALS.yaml status tracking
+- `sessions_spawn` (optional) — run multiple deal pipelines in parallel
+
+## Setup
+
+Add these MCP servers to your configuration:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": { "FIRECRAWL_API_KEY": "your-key" }
+    },
+    "calcom": {
+      "command": "npx",
+      "args": ["-y", "@calcom/mcp"],
+      "env": { "CAL_API_KEY": "your-key" }
+    },
+    "signbee": {
+      "command": "npx",
+      "args": ["-y", "signbee-mcp"],
+      "env": { "SIGNBEE_API_KEY": "your-key" }
+    }
+  }
+}
+```
+
+## Example Prompt
+
+```text
+I need to close a partnership deal with the company at https://acme.io.
+
+1. Scrape their site using Firecrawl. Find the founder or CTO name and email.
+2. Draft a short, personalised partnership email. Reference something specific
+   from their product page. Include my Cal.com booking link for a 30-min call.
+3. After I confirm the call went well, generate a simple services agreement
+   in markdown. Include both party names, scope of work, and payment terms.
+4. Send the agreement for signing via Signbee to the contact you found.
+5. Track everything in DEALS.yaml with status updates after each step.
+```
+
+## DEALS.yaml Format
+
+```yaml
+deals:
+  - company: acme.io
+    contact: Jane Smith (CTO)
+    email: jane@acme.io
+    status: contract_sent
+    steps:
+      research: done
+      outreach: done
+      meeting: done
+      contract_drafted: done
+      signing: pending
+    signbee_document_id: doc_abc123
+    updated: 2026-04-01T10:30:00Z
+```
+
+## Key Insights
+
+- **Chain MCP tools, don't use them in isolation.** The power isn't any single tool. It's combining Firecrawl + email + Cal.com + Signbee into one uninterrupted flow.
+- **Markdown contracts work.** Agents think in text. Keeping contracts as markdown means the agent can draft, edit, and iterate without leaving the terminal. Signbee converts markdown to PDF automatically.
+- **Free tiers cover testing.** Firecrawl, Cal.com, and Signbee all have free plans. You can test the full pipeline without spending anything.
+- **Use subagents for parallel deals.** Spawn one subagent per prospect with `sessions_spawn` and let them all run independently. Track status via DEALS.yaml.
+
+## Related Links
+
+- [Firecrawl MCP](https://github.com/mendableai/firecrawl)
+- [Cal.com](https://cal.com)
+- [Signbee MCP](https://www.npmjs.com/package/signbee-mcp)
+- [AgentMail](https://agentmail.to) (alternative email MCP for agent-native email)


### PR DESCRIPTION
## New Use Case: Autonomous Deal Closer

Chains multiple MCP servers into a single B2B deal pipeline:

1. **Firecrawl MCP** → scrape prospect website, extract contacts
2. **Gmail/AgentMail** → send personalised outreach
3. **Cal.com MCP** → book meetings with availability links
4. **Signbee MCP** → draft contract and collect e-signatures
5. **DEALS.yaml** → track pipeline status across all steps

### Why this is useful
Most use cases here show single-tool workflows. This one demonstrates chaining 4-5 MCP servers into a complete business workflow that runs end-to-end with minimal intervention. The pattern (research → outreach → meeting → contract → sign) is replicable for any B2B context.

### Tested and verified
I've been running this pipeline for my own deal flow for the past few weeks. All MCP servers referenced have free tiers for testing.

### Changes
- Added `usecases/autonomous-deal-closer.md`
- Added row to Productivity table in README.md

Category: **Productivity**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive Autonomous Deal Closer use-case documentation describing a complete end-to-end sales automation workflow that integrates prospect research capabilities, personalized email outreach, intelligent meeting scheduling, automated contract generation with custom deal terms, digital signature collection and management, and persistent deal progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->