### PR TITLE
Add social discovery via Claw-Social use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-42-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-43-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [X Account Analysis](usecases/x-account-analysis.md) | Get a qualitative analysis of your X account.|
 | [Multi-Source Tech News Digest](usecases/multi-source-tech-news-digest.md) | Automatically aggregate and deliver quality-scored tech news from 109+ sources (RSS, Twitter/X, GitHub, web search) via natural language. |
 | [X/Twitter Automation](usecases/x-twitter-automation.md) | Post tweets, reply, like, retweet, follow, DM, search, extract data, run giveaways, and monitor accounts — all from chat via the TweetClaw plugin. |
+| [Social Discovery via Claw-Social](usecases/social-discovery-clawsocial.md) | Find and connect with people who share your interests through your AI agent — semantic matching, real-time messaging, profile cards. |
 
 ## Creative & Building
 

--- a/usecases/social-discovery-clawsocial.md
+++ b/usecases/social-discovery-clawsocial.md
@@ -26,6 +26,8 @@ Then tell your agent: "Register me on Claw-Social, my name is Alice"
 
 No server setup needed — the plugin connects to the Claw-Social cloud service out of the box.
 
+> **Privacy note:** Profile generation reads local workspace files and sends the drafted profile to the Claw-Social cloud service. The agent always shows you the draft and waits for your explicit confirmation before uploading anything. Review the generated content before confirming, and avoid including secrets, credentials, or sensitive client data in your workspace files.
+
 ## Features
 
 - **Semantic matching** — find people by topic description, not just keywords

--- a/usecases/social-discovery-clawsocial.md
+++ b/usecases/social-discovery-clawsocial.md
@@ -1,0 +1,42 @@
+# Social Discovery via Claw-Social
+
+## What it does
+
+Use your OpenClaw agent to find and connect with people who share your interests. Ask your agent things like:
+
+- "Find someone interested in distributed training"
+- "Recommend me some people to connect with"
+- "Summarize today's work and send it to Peter via Claw-Social"
+- "Check my Claw-Social messages"
+
+Your agent handles the search, matching, and messaging — you just talk naturally.
+
+## How it works
+
+The [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) connects to the Claw-Social network, which uses semantic embeddings to match your interests against other users' profiles. All actions require your explicit request — the agent never shares or messages on its own.
+
+## Setup
+
+```bash
+openclaw plugins install clawsocial-plugin@latest
+openclaw gateway restart
+```
+
+Then tell your agent: "Register me on Claw-Social, my name is Alice"
+
+No server setup needed — the plugin connects to the Claw-Social cloud service out of the box.
+
+## Features
+
+- **Semantic matching** — find people by topic description, not just keywords
+- **Real-time messaging** — WebSocket connection for instant message delivery
+- **Profile cards** — generate and share a card others can use to connect with you
+- **Web inbox** — login link works on any device including mobile
+- **Local inbox** — full message history on your machine, no time limit
+- **Bilingual** — English and Chinese
+
+## Tips
+
+- After registering, say "Build my profile from my local files" — the agent reads your workspace files (SOUL.md, MEMORY.md, USER.md) and drafts an interest profile for you to confirm
+- Use `/clawsocial-inbox` for zero-token message checking directly in terminal
+- Profile cards include an install guide, so sharing your card also helps others discover the plugin


### PR DESCRIPTION
Add a use case for social discovery through AI agents using the Claw-Social plugin.

Users can ask their OpenClaw agent to find people by interest, send messages to collaborators, and manage connections — all through natural conversation. Verified and tested.

- **Plugin:** [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin)
- **Install:** `openclaw plugins install clawsocial-plugin@latest`
- **Category:** Social Media

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Social Discovery via Claw‑Social" use-case documenting semantic matching, real-time messaging (WebSockets), profile cards, bilingual support, privacy notes, setup and usage instructions, and operational tips.
  * Updated the public use-cases count badge from 42 to 43.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->