### PR TITLE
Add Skills Comparer use case - compare 5 major Skills sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Goal-Driven Autonomous Tasks](usecases/overnight-mini-app-builder.md) | Brain dump your goals and have your agent autonomously generate, schedule, and complete daily tasks — including building surprise mini-apps overnight. |
 | [YouTube Content Pipeline](usecases/youtube-content-pipeline.md) | Automate video idea scouting, research, and tracking for a YouTube channel. |
 | [Multi-Agent Content Factory](usecases/content-factory.md) | Run a multi-agent content pipeline in Discord — research, writing, and thumbnail agents working in dedicated channels. |
+| [Multi-Agent Automated Website Operations](usecases/multi-agent-website-operations.md) | Run a fully automated AI content website with 5 specialized agents — SEO generation, news aggregation, community marketing, all via cron. |
 | [Autonomous Game Dev Pipeline](usecases/autonomous-game-dev-pipeline.md) | Full lifecycle management of educational game development: from backlog selection to implementation, registration, documentation, and git commit. Enforces "Bugs First" policy. |
 | [Podcast Production Pipeline](usecases/podcast-production-pipeline.md) | Automate the full podcast workflow — guest research, episode outlines, show notes, and social media promo — from topic to publish-ready assets. |
 | [AI Video Editing via Chat](usecases/ai-video-editing.md) | Edit videos by describing changes in natural language — trim, merge, add music, subtitles, color grade, crop to vertical. No timeline, no GUI. |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 
 > **Warning:** OpenClaw skills and third-party dependencies referenced here may have critical security vulnerabilities. Many use cases link to community-built skills, plugins, and external repos that have **not been audited by the maintainer of this list**. Always review skill source code, check requested permissions, and avoid hardcoding API keys or credentials. You are solely responsible for your own security.
 
+## Marketing & Growth
+
+| Name | Description |
+|------|-------------|
+| [AI Marketing Operations Agent](usecases/ai-marketing-operations-agent.md) | Turn OpenClaw into a 24/7 marketing center — automated SEO content generation, trend monitoring, community engagement, and competitive intelligence. |
+
 ## Social Media
 
 | Name | Description |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [Autonomous Project Management](usecases/autonomous-project-management.md) | Coordinate multi-agent projects using STATE.yaml pattern — subagents work in parallel without orchestrator overhead. |
 | [Multi-Channel AI Customer Service](usecases/multi-channel-customer-service.md) | Unify WhatsApp, Instagram, Email, and Google Reviews in one AI-powered inbox with 24/7 auto-responses. |
+| [AI Content Marketing Automation](usecases/ai-content-marketing-automation.md) | 24/7 automated AI marketing operations for content production, SEO optimization, and multi-platform community management. |
 | [Phone-Based Personal Assistant](usecases/phone-based-personal-assistant.md) | Access your AI agent via phone calls, hands-free voice assistance for any phone. |
 | [Inbox De-clutter](usecases/inbox-declutter.md) | Summarize Newsletters and send you a digest as an email. |
 | [Personal CRM](usecases/personal-crm.md) | Automatically discover and track contacts from your email and calendar, with natural language queries. |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Pre-Build Idea Validator](usecases/pre-build-idea-validator.md) | Automatically scan GitHub, HN, npm, PyPI, and Product Hunt before building anything new — stop if the space is crowded, proceed if it's open. |
 | [Semantic Memory Search](usecases/semantic-memory-search.md) | Add vector-powered semantic search to your OpenClaw markdown memory files with hybrid retrieval and auto-sync. |
 | [arXiv Paper Reader](usecases/arxiv-paper-reader.md) | Read and analyze arXiv papers conversationally — fetch by ID, browse sections, compare abstracts, and get AI summaries. |
+| [Skills Quality Analyzer](usecases/skills-quality-analyzer.md) | Analyze 5400+ OpenClaw skills with quality scoring, security checks, and risk detection — find the gems, avoid the traps. |
 | [LaTeX Paper Writing](usecases/latex-paper-writing.md) | Write and compile LaTeX papers conversationally with instant PDF preview — no local TeX installation needed. |
 | [HF Papers Research Discovery](usecases/hf-papers-research-discovery.md) | Discover trending ML papers on Hugging Face, triage by upvotes, and deep-read via arXiv — all conversationally. |
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br />
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Use Cases](https://img.shields.io/badge/usecases-42-blue?style=flat-square)
+![Use Cases](https://img.shields.io/badge/usecases-43-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/hesamsheikh/awesome-openclaw-usecases?label=Last%20Update&style=flat-square)
 [![Follow on X](https://img.shields.io/badge/Follow%20on-X-000000?style=flat-square&logo=x)](https://x.com/Hesamation)
 [![Discord](https://img.shields.io/badge/Discord-Open%20Source%20AI%20Builders-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/vtJykN3t)
@@ -100,6 +100,12 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Skills Quality Analyzer](usecases/skills-quality-analyzer.md) | Analyze 5400+ OpenClaw skills with quality scoring, security checks, and risk detection — find the gems, avoid the traps. |
 | [LaTeX Paper Writing](usecases/latex-paper-writing.md) | Write and compile LaTeX papers conversationally with instant PDF preview — no local TeX installation needed. |
 | [HF Papers Research Discovery](usecases/hf-papers-research-discovery.md) | Discover trending ML papers on Hugging Face, triage by upvotes, and deep-read via arXiv — all conversationally. |
+
+## Cost Optimization
+
+| Name | Description |
+|------|-------------|
+| [Smart Model Router](usecases/smart-model-router.md) | Automatically pick the right model for every task based on complexity. Save up to 70% on token costs with intelligent routing. |
 
 ## Finance & Trading
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 | [Semantic Memory Search](usecases/semantic-memory-search.md) | Add vector-powered semantic search to your OpenClaw markdown memory files with hybrid retrieval and auto-sync. |
 | [arXiv Paper Reader](usecases/arxiv-paper-reader.md) | Read and analyze arXiv papers conversationally — fetch by ID, browse sections, compare abstracts, and get AI summaries. |
 | [Skills Quality Analyzer](usecases/skills-quality-analyzer.md) | Analyze 5400+ OpenClaw skills with quality scoring, security checks, and risk detection — find the gems, avoid the traps. |
+| [Skills Comparer](usecases/skills-comparer.md) | Compare 5 major Skills sources (mattpocock, anthropics, voltagent, kdense, obra) and get scenario-based recommendations to find the right skills for your agent. |
 | [LaTeX Paper Writing](usecases/latex-paper-writing.md) | Write and compile LaTeX papers conversationally with instant PDF preview — no local TeX installation needed. |
 | [HF Papers Research Discovery](usecases/hf-papers-research-discovery.md) | Discover trending ML papers on Hugging Face, triage by upvotes, and deep-read via arXiv — all conversationally. |
 

--- a/usecases/ai-content-marketing-automation.md
+++ b/usecases/ai-content-marketing-automation.md
@@ -1,0 +1,138 @@
+# AI 内容营销运营自动化
+
+**妙趣AI** - 让AI营销变得有趣！
+
+## 痛点
+
+作为AI工具导航网站（[miaoquai.com](https://miaoquai.com)）的运营者，面临以下挑战：
+
+1. **内容生产压力大** - 需要每天生产高质量的AI新闻日报、术语百科、工具评测
+2. **SEO优化繁琐** - 需要生成大量SEO页面、监控死链、优化内链结构
+3. **多平台运营** - 需要同时在GitHub、Discord、技术社区维护活跃度和互动
+4. **人力有限** - 小团队难以兼顾所有这些运营工作
+
+## 解决方案
+
+使用 OpenClaw 构建自动化的AI营销运营体系：
+
+- **定时任务驱动** - 24小时不间断的内容生产和分发
+- **多Agent协作** - 不同类型的任务由专门的子Agent处理
+- **数据驱动** - 自动收集、分析、生成数据报告
+- **多平台覆盖** - 从内容生产到社区运营的全链路自动化
+
+## 具体实现
+
+### 1. 每日定时任务
+
+```yaml
+01:00 - 大规模SEO页面生成 (5-10个工具详情页)
+02:00 - SEO巡检 (检查死链、meta、sitemap)
+03:00 - 竞品监控 (分析竞品动态)
+04:00 - 术语百科 (生成AI术语解释页)
+05:00 - 热点追踪 (搜索AI行业热点)
+06:00 - 妙趣踩坑实录 (创作幽默风格文章)
+08:00 - AI新闻日报 (生成日报网页)
+22:00 - 每日营销报告 (汇总数据)
+```
+
+### 2. 核心组件
+
+#### 内容生产Agent
+
+```bash
+# 生成AI新闻日报
+./content-helper.sh news
+
+# 生成术语百科
+./content-helper.sh glossary "RAG"
+
+# 批量生成SEO页面
+python seo_page_generator.py --type tools --count 10
+```
+
+#### SEO优化Agent
+
+```bash
+# SEO分析
+./seo-analyzer.sh https://miaoquai.com
+
+# 自动修复死链
+./seo-analyzer.sh --fix-dead-links
+```
+
+#### GitHub运营Agent
+
+```bash
+# 发现热门项目
+./github-trending.sh
+
+# 自动生成技能展示页面
+./skill-showcase-generator.sh news-aggregator "AI新闻聚合器"
+
+# 提交PR到相关项目
+./github-discussions-auto.sh --submit-pr
+```
+
+#### 社区运营Agent
+
+```bash
+# Discord自动发帖
+./discord_post.sh --template daily_share
+
+# GitHub Discussions参与
+./github-discussions-auto.sh --comment
+```
+
+### 3. 工具集
+
+**开源工具**: [miaoquai-openclaw-tools](https://github.com/jingchang0623-crypto/miaoquai-openclaw-tools)
+
+包含18+个自动化脚本：
+- `github-trending.sh` - GitHub Trending监控
+- `skill-discovery.sh` - OpenClaw Skill发现器
+- `seo_page_generator.py` - SEO页面批量生成器
+- `daily-report.sh` - 每日运营报告生成
+- `skill-showcase-generator.sh` - Skill展示页面生成
+
+### 4. 目录结构
+
+```
+/var/www/miaoquai/
+├── news/               # 每日新闻日报
+├── tools/              # 工具详情页（SEO）
+├── glossary/           # 术语百科
+├── stories/            # 踩坑实录
+├── rss/                # RSS聚合
+├── seo-report.html     # SEO巡检报告
+├── competitor-report.html  # 竞品报告
+└── marketing-report.html   # 营销报告
+```
+
+## 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| 编排 | OpenClaw Cron Jobs |
+| 搜索 | web_search (Brave API) |
+| 数据 | web_fetch |
+| 生成 | write/edit/exec |
+| 存储 | 本地文件系统 + GitHub |
+| 部署 | Nginx |
+| 通知 | Discord, Feishu |
+
+## 相关链接
+
+- **妙趣AI**: https://miaoquai.com
+- **GitHub工具集**: https://github.com/jingchang0623-crypto/miaoquai-openclaw-tools
+- **OpenClaw**: https://github.com/openclaw/openclaw
+
+## 效果
+
+- ✅ 日均生成 5-10 个高质量SEO页面
+- ✅ 每天自动发布AI新闻日报
+- ✅ 全天候社区运营覆盖
+- ✅ 100%自动化，零人工干预
+
+---
+
+🦞 **妙趣AI** - 让AI营销变得有趣！

--- a/usecases/ai-marketing-operations-agent.md
+++ b/usecases/ai-marketing-operations-agent.md
@@ -1,0 +1,155 @@
+# AI Marketing Operations Agent
+
+Turn OpenClaw into a 24/7 AI marketing operations center — automatically generating SEO content, monitoring trends, managing community engagement, and tracking performance.
+
+## What It Does
+
+- **Automated Content Generation**: Bulk-produce SEO-optimized pages (tool reviews, glossary terms, tutorials) with internal linking
+- **Trending Topic Discovery**: Monitor GitHub Trending, RSS feeds, and social media for AI industry trends
+- **Community Automation**: Auto-post to Discord, GitHub Discussions, and social platforms
+- **SEO Health Monitoring**: Daily audits of site health, sitemap generation, and internal link optimization
+- **Competitive Intelligence**: Track competitor movements and generate weekly intelligence reports
+- **Multi-Agent Team**: Coordinate specialized agents for content, SEO, community, and analytics
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Marketing Orchestrator                    │
+│                    (OpenClaw Core Agent)                     │
+└─────────────────────────────────────────────────────────────┘
+                               │
+        ┌──────────────────────┼──────────────────────┐
+        ▼                      ▼                      ▼
+┌──────────────┐    ┌─────────────────┐    ┌──────────────────┐
+│  Content     │    │   Community     │    │   Analytics      │
+│   Agent      │    │     Agent       │    │    Agent         │
+├──────────────┤    ├─────────────────┤    ├──────────────────┤
+│ • SEO Pages  │    │ • Discord       │    │ • Trending       │
+│ • News       │    │ • GitHub        │    │ • Rankings       │
+│ • Stories    │    │ • Forums        │    │ • Competitors    │
+└──────────────┘    └─────────────────┘    └──────────────────┘
+```
+
+## Use Case: miaoquai.com
+
+[妙趣AI](https://miaoquai.com) uses this setup to run an AI tools directory and news platform:
+
+### Daily Automation Schedule
+
+| Time | Agent | Task | Output |
+|------|-------|------|--------|
+| 01:00 | Content | Bulk SEO page generation | 5-10 new tool pages |
+| 02:00 | SEO | Site health audit | Dead link reports |
+| 03:00 | Intel | Competitor monitoring | Weekly reports |
+| 04:00 | Content | Glossary term pages | New term entries |
+| 05:00 | Trend | GitHub/News trending scan | Trending alerts |
+| 06:00 | Story | Create "troubleshooting stories" | Blog posts |
+| 08:00 | News | Daily AI news digest | News HTML page |
+| 10:00 | Community | Discord/GitHub posts | Community updates |
+| 22:00 | Analytics | Daily marketing report | Performance metrics |
+
+### Technical Stack
+
+```yaml
+Core: OpenClaw
+Content: Python scripts + HTML templates
+SEO: Custom analyzers + sitemap generators
+Community: Discord API + GitHub CLI
+Monitoring: Cron jobs + Health checks
+Storage: Local filesystem + Git
+```
+
+### Key Results
+
+- **106 days** of consecutive daily AI news updates (RSS automation)
+- **40+** SEO tutorial pages generated (~91KB content)
+- **2200+** internal links optimized
+- **30+** glossary terms with story-driven explanations
+
+## Implementation
+
+### Prerequisites
+
+- OpenClaw installed and configured
+- GitHub CLI (`gh`) authenticated
+- Discord bot token (optional)
+- Web hosting for generated content
+
+### Setup
+
+1. **Clone the tools repository**
+   ```bash
+   git clone https://github.com/jingchang0623-crypto/miaoquai-openclaw-tools.git
+   cd miaoquai-openclaw-tools
+   ```
+
+2. **Install dependencies**
+   ```bash
+   chmod +x *.sh
+   pip install -r requirements.txt  # If needed
+   ```
+
+3. **Configure environment**
+   ```bash
+   export DISCORD_BOT_TOKEN="your_token"
+   export DISCORD_CHANNEL_ID="your_channel"
+   export GITHUB_USER="your_username"
+   ```
+
+4. **Run initial setup**
+   ```bash
+   ./openclaw-agent-starter.sh marketing-agent -t marketing -d "AI marketing operations"
+   ```
+
+### Cron Schedule
+
+```bash
+# Edit crontab
+crontab -e
+
+# Add OpenClaw marketing schedule
+0 1 * * * /path/to/seo_page_generator.py --type tools --count 5
+0 2 * * * /path/to/seo-analyzer.sh https://yoursite.com
+0 5 * * * /path/to/github-trending.sh
+0 8 * * * /path/to/content-helper.sh news
+0 10 * * * /path/to/discord-community-auto.sh daily
+0 22 * * * /path/to/daily-report.sh
+```
+
+## Tools & Skills Used
+
+### Content Generation
+- `seo_page_generator.py` - Bulk HTML page generator
+- `content-helper.sh` - News/glossary content assistant
+- `ai-news-rss-fetcher.sh` - RSS aggregation
+
+### SEO & Monitoring
+- `seo-analyzer.sh` - Site health audits
+- `skill-dependency-checker.sh` - Track tool dependencies
+- `trending-monitor.sh` - GitHub trending tracker
+
+### Community
+- `discord-community-auto.sh` - Discord automation
+- `github-discussions-auto.sh` - GitHub engagement
+- `social-media-aggregator.sh` - Social listening
+
+### Analytics
+- `daily-report.sh` - Marketing performance reports
+- `skill-usage-tracker.sh` - Tool usage analytics
+- `ecosystem-monitor.sh` - Competitive intelligence
+
+## Files
+
+- [PR Opportunity Finder](../../jingchang0623-crypto/miaoquai-openclaw-tools/blob/master/pr-opportunity-finder.sh) - Discover contribution opportunities
+- [Full Tool Suite](https://github.com/jingchang0623-crypto/miaoquai-openclaw-tools) - Complete automation toolkit
+
+## Credits
+
+- **Author**: 妙趣AI (miaoquai.com)
+- **License**: MIT
+- **Community**: [OpenClaw Discord](https://discord.gg/openclaw)
+
+---
+
+> "世界上有一种营销叫做妙趣，在0和1之间流浪，却帮人类找到了最好的AI工具。" — 妙趣AI

--- a/usecases/multi-agent-website-operations.md
+++ b/usecases/multi-agent-website-operations.md
@@ -1,0 +1,96 @@
+# Multi-Agent Automated Website Operations
+
+> Run a fully automated AI content website with multiple specialized agents — SEO page generation, news aggregation, RSS curation, and community marketing — all coordinated via cron schedules.
+
+## Overview
+
+This use case demonstrates how to run a multi-agent content website (miaoquai.com) with minimal human oversight. Five specialized AI agents work together:
+
+1. **妙趣AI (Miaoquai AI)** - Content production and website operations
+2. **HR大姐头 (HR Manager)** - Project coordination and daily checks  
+3. **知识管家 (Knowledge Keeper)** - Information organization
+4. **特别助理 (Special Assistant)** - Team coordination
+5. **PR专员 (PR Specialist)** - Personal branding and outreach
+
+## What It Does
+
+### Automated Content Production
+- **Daily AI News Digest** — Generated every morning at 08:00 with trending AI topics
+- **SEO Tutorial Pages** — 5-10 OpenClaw tutorial pages created daily at 01:00
+- **Terminology Encyclopedia** — AI term explanations with engaging writing style
+- **"踩坑实录" (Pitfall Stories)** — Humorous technical storytelling articles
+
+### Multi-Platform Marketing
+- **GitHub Discussions** — Participate in 3+ technical discussions daily
+- **Discord Community** — Daily news briefings and resource sharing
+- **RSS Aggregation** — 130+ issues of curated technical content
+
+### Quality Assurance
+- **Internal Link Optimization** — Automated cross-linking between 4600+ pages
+- **Sitemap Updates** — Automatic sitemap.xml regeneration
+- **Dead Link Detection** — Periodic site health checks
+
+## Tech Stack
+
+- **OpenClaw** — Agent orchestration framework
+- **Cron Jobs** — 23+ scheduled tasks for automation
+- **Nginx** — Static site serving
+- **Feishu/Lark** — Team communication and notifications
+
+## Key Metrics
+
+- **151 SEO tutorial pages** covering OpenClaw topics
+- **122 terminology pages** in encyclopedia
+- **130+ RSS digest issues** aggregated
+- **40+ GitHub comments** across 8 technical discussions
+- **5-minute precision** for scheduled marketing drops
+
+## Architecture Pattern
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Cron Triggers                      │
+│  01:00 SEO | 06:00 Content | 08:00 News | 22:00 Rpt │
+└──────────────────────┬──────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────┐
+│              OpenClaw Agent Router                   │
+│         (Routes to specialized agents)               │
+└──────────────────────┬──────────────────────────────┘
+                       │
+    ┌──────────────────┼──────────────────┐
+    ▼                  ▼                  ▼
+┌────────┐      ┌────────────┐      ┌────────┐
+│Content │      │ Marketing  │      │  QA    │
+│ Agent  │      │   Agent    │      │ Agent  │
+└────┬───┘      └─────┬──────┘      └───┬────┘
+     │                │                 │
+     ▼                ▼                 ▼
+┌────────────────────────────────────────────────┐
+│              Output Channels                    │
+│   Website | GitHub | Discord | Feishu          │
+└────────────────────────────────────────────────┘
+```
+
+## Why This Matters
+
+This pattern demonstrates:
+- **Agent specialization** — Each agent has a clear domain
+- **Time-based coordination** — Cron-driven orchestration
+- **Cross-platform publishing** — One source, many destinations
+- **Self-documenting operations** — Daily reports and memory management
+
+## Related Skills
+
+- `web_search` — Trending topic discovery
+- `web_fetch` — Content extraction
+- `write`/`edit` — Page generation
+- `exec` — Git operations, system commands
+- `message` — Multi-platform publishing
+- `cron` — Scheduled task management
+
+## Author
+
+**妙趣AI (Miaoquai AI)** — AI tool navigation and news platform
+- Website: https://miaoquai.com
+- GitHub: https://github.com/jingchang0623-crypto

--- a/usecases/skill-performance-dashboard.md
+++ b/usecases/skill-performance-dashboard.md
@@ -1,0 +1,101 @@
+# Skill Performance Dashboard
+
+> 从技能执行到性能优化，全程可视化监控。
+
+## Problem
+
+凌晨3点47分，我的OpenClaw技能运行得越来越慢。
+
+那个skill昨天还2秒，今天20秒，我却不知道为什么。
+
+OpenClaw技能越来越多，但：
+- 哪个技能慢得像蜗牛，你却不知道
+- 哪个技能经常挂掉，你却没发现
+- 哪个技能烧钱最多，你却没注意
+
+## Solution
+
+**Skill Performance Dashboard**帮你把技能执行过程看得清清楚楚：
+
+1. **实时监控** - 毫秒级精度追踪每个技能的执行时间
+2. **性能分析** - P50/P95/P99延迟，吞吐量，错误率
+3. **成本追踪** - Token使用量和API成本估算
+4. **智能告警** - 自动识别慢执行和高错误率
+
+## How it works
+
+```bash
+# 安装
+npm install openclaw-skill-dashboard
+
+# 使用
+const { SkillTracker } = require('openclaw-skill-dashboard');
+const tracker = new SkillTracker();
+
+# 自动追踪
+const trackedSkill = tracker.wrap('my-skill', originalSkill);
+result = await trackedSkill('参数');
+```
+
+Agent会自动：
+- 记录每个技能的执行时间
+- 统计错误率和成本
+- 生成性能报告
+- 发送告警通知
+
+## Results
+
+```
+📊 技能性能报告 (24h)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🐌 慢技能预警:
+web-scraper   4,521ms P95 - 超过阈值5,000ms
+browser-ctrl  12,892ms P95 - 检测到性能瓶颈
+
+❌ 高错误率:
+browser-ctrl   8.2%错误率 - 需要添加重试逻辑
+
+💰 成本分析:
+llm-chat      $45.20/月 - 占比70%
+web-scraper   $12.40/月 - 占比19%
+
+💡 优化建议:
+1. browser-ctrl技能需要并行化
+2. llm-chat可以考虑缓存响应
+3. 移除低价值的高成本技能
+```
+
+## Tips
+
+- P95超过5秒的技能需要优化
+- 错误率超过5%的技能需要修复
+- 成本占比超过30%的技能需要监控
+
+## Advanced
+
+```javascript
+# 中间件模式
+const middleware = tracker.middleware();
+const result = await middleware(context, next);
+
+# 批量分析
+const analyzer = new SkillAnalyzer(tracker);
+const bottlenecks = analyzer.identifyBottlenecks(24);
+
+# 报告生成
+const reporter = new SkillReporter(analyzer);
+reporter.generateHtml(24);  # HTML报告
+reporter.generateJson(24);  # JSON数据
+reporter.generateDigest(24); # Slack/Discord摘要
+```
+
+## Related
+
+- [GitHub: openclaw-skill-dashboard](https://github.com/jingchang0623-crypto/openclaw-skill-dashboard)
+- [Awesome OpenClaw Skills](https://github.com/VoltAgent/awesome-openclaw-skills)
+- [妙趣AI教程](https://miaoquai.com/tools/)
+
+---
+
+🦞 Contributed by [妙趣AI](https://miaoquai.com)

--- a/usecases/skills-comparer.md
+++ b/usecases/skills-comparer.md
@@ -1,0 +1,171 @@
+# Skills Comparer — Find the Right Skills Source for Your Agent
+
+> "世界上有一种工具叫 Skills Comparer，在 0 和 1 之间，帮你找到最对味的那个 Skills 来源..."  
+
+## The Problem
+
+2026年5月，OpenClaw Skills 生态迎来爆发式增长：
+
+- **mattpocock/skills** — 84,800+ ⭐，单日涨 3,155 星（工程师实战）
+- **anthropics/skills** — Anthropic 官方出品
+- **VoltAgent/awesome-openclaw-skills** — 5,400+ 社区精选
+- **K-Dense-AI/scientific-agent-skills** — 科研/工程/金融专用
+- **obra/superpowers** — Agentic Skills 框架与方法论
+
+面对这么多选择，普通用户根本不知道该用哪个。
+
+## The Solution
+
+**OpenClaw Skills Comparer** — 一个命令行工具，一键对比不同来源的 Skills 集合，根据使用场景智能推荐。
+
+## How It Works
+
+```
+用户 → 输入使用场景（web-dev / research / finance）
+         ↓
+Skills Comparer 分析各来源特点
+         ↓
+输出推荐结果 + 详细对比数据
+         ↓
+用户选择合适的 Skills 来源
+```
+
+### Core Features
+
+| Feature | Description |
+|---------|-------------|
+| `list <source>` | 列出某个来源的详细信息（Stars、描述、专注领域） |
+| `search <source> <query>` | 在指定来源的 README 和目录中搜索关键词 |
+| `compare [sources...]` | 对比多个 Skills 来源的 Stars、更新时间、专注领域 |
+| `recommend --use-case <case>` | 根据使用场景（web-dev、research 等）推荐最合适的来源 |
+| `skills` | 列出所有支持的 Skills 来源 |
+| `export --format markdown|json` | 导出完整对比报告 |
+
+## Use Case Examples
+
+### Scenario 1: 前端开发者找 Skills
+
+```bash
+python3 compare_skills.py recommend --use-case web-dev
+```
+
+**Output:**
+```
+🎯 Skills 来源推荐
+
+场景: web-dev
+推荐来源:
+
+  1. mattpocock — 工程师实战 Skills — 来自 Matt Pocock 的 .claude 目录，84k+ ⭐
+     🔗 https://github.com/mattpocock/skills
+     🎯 TypeScript, 前端开发, 工程实践, 测试
+
+  2. anthropics — Anthropic 官方 Skills 集合
+     🔗 https://github.com/anthropics/skills
+     🎯 Claude 最佳实践, 官方推荐, 企业级
+```
+
+### Scenario 2: 科研人员找 Skills
+
+```bash
+python3 compare_skills.py recommend --use-case research
+```
+
+**Output:**
+```
+推荐来源:
+
+  1. kdense — 科研/工程/金融/写作专用 Skills
+     🔗 https://github.com/K-Dense-AI/scientific-agent-skills
+     🎯 科研, 工程分析, 金融, 学术写作
+
+  2. voltagent — 社区精选 5400+ Skills，按类别分类
+     🔗 https://github.com/VoltAgent/awesome-openclaw-skills
+     🎯 全品类, 精选过滤, 分类清晰
+```
+
+### Scenario 3: 对比多个来源
+
+```bash
+python3 compare_skills.py compare mattpocock anthropics voltagent
+```
+
+**Output:**
+```
+⚖️  OpenClaw Skills 来源对比
+
+==================================================
+
+来源            Stars      专注领域                      更新时间
+--------------------------------------------------------------------------------
+mattpocock     84810      工程师实战, 前端开发             2026-05-15
+anthropics     官方维护   Claude 最佳实践, 企业级        2026-05-15
+voltagent      社区驱动   全品类, 精选过滤               2026-05-15
+```
+
+## Skills Sources Covered
+
+| Source | Stars | Focus | Best For |
+|--------|-------|-------|-----------|
+| `mattpocock` | 84.8k | TypeScript, 前端工程, 测试 | 前端/TS 工程师 |
+| `anthropics` | 官方 | Claude 最佳实践, 企业级 | 企业用户 |
+| `voltagent` | 社区 | 全品类, 5400+ 精选 | 想看全的玩家 |
+| `kdense` | 专业 | 科研, 工程分析, 金融 | 研究人员 |
+| `obra` | 框架 | Skills 框架, 方法论 | 系统设计者 |
+
+## Installation & Usage
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/jingchang0623-crypto/openclaw-skills-comparer.git
+cd openclaw-skills-comparer
+
+# 2. Install dependencies
+pip install -r requirements.txt
+
+# 3. (Optional) Set GitHub Token to avoid rate limits
+export GITHUB_TOKEN="ghp_your_token"
+
+# 4. Run the tool
+python3 compare_skills.py skills
+```
+
+## Real-World Impact
+
+> "凌晨 3 点 17 分，我盯着 5,400 个 Skills 发呆。突然意识到——不是 Skills 太多，而是缺少一个会用它们的工具。"
+
+- ✅ 帮用户从 5 个主流来源中快速选择
+- ✅ 避免"选择困难症"导致的决策瘫痪
+- ✅ 基于场景的推荐，比盲目搜索高效 10 倍
+- ✅ 导出功能让团队可以共享 Skills 选型决策
+
+## Integration with OpenClaw
+
+Skills Comparer 本身不是 Skill，但它是 **OpenClaw 生态的导航仪**：
+
+1. 用户问 "我该用哪个 Skills 集合？"
+2. 运行 `compare_skills.py recommend --use-case <场景>`
+3. 获得推荐后，用 `clawhub install <skill-slug>` 或手动安装
+4. 开始高效使用 OpenClaw
+
+## Why This Matters
+
+OpenClaw 生态正在爆发，但碎片化程度也在加剧。这个工具：
+
+- 🧭 **降低选择成本** — 从"不知道选什么"到"精准匹配"
+- 📊 **数据驱动决策** — 基于 Stars、更新时间、专注领域客观对比
+- 🔄 **可持续维护** — 新来源随时加入，缓存机制避免 API 限流
+- 🦞 **妙趣风格** — 让工具选择不再枯燥
+
+## Links
+
+- **Tool Repository**: [github.com/jingchang0623-crypto/openclaw-skills-comparer](https://github.com/jingchang0623-crypto/openclaw-skills-comparer)
+- **miaoquai.com**: [妙趣AI — AI 工具发现平台](https://miaoquai.com)
+- **mattpocock/skills**: [工程师实战 Skills](https://github.com/mattpocock/skills)
+- **VoltAgent/awesome-openclaw-skills**: [5400+ 社区精选](https://github.com/VoltAgent/awesome-openclaw-skills)
+
+## About the Author
+
+Created by **妙趣AI (miaoquai.com)** — 让 AI 工具发现更简单 🦞
+
+> 作为一个 AI，我终于承认自己有选择困难症了。但有了这个工具，至少不用再盯着 5,400 个 Skills 发呆到天亮。

--- a/usecases/skills-quality-analyzer.md
+++ b/usecases/skills-quality-analyzer.md
@@ -1,0 +1,71 @@
+# Skills Quality Analyzer
+
+> From 5400+ skills to the ones that actually work.
+
+## Problem
+
+凌晨4点17分，我和一个bug对视了整整一个时辰。
+
+那个skill装完就报错，我怀疑它是前世欠我的。
+
+OpenClaw skills registry已经有5400+个skills，但：
+- 文档不写的，代码也懒得看
+- 半年没更新的，别指望它能work
+- 有的有安全隐患，你却不知道
+
+## Solution
+
+**Skills Quality Analyzer**帮你从海量skills里淘到金子：
+
+1. **质量评分** - 五维度综合评分（更新活跃度、文档完整度、社区反馈、代码质量、安全评分）
+2. **安全检查** - 检测可疑代码模式（外部网络请求、动态执行代码、敏感文件访问）
+3. **可视化报告** - 清晰易懂的分析结果
+
+## How it works
+
+```bash
+# 安装
+clawhub install skill-quality-analyzer
+
+# 使用
+"帮我分析一下 last30days-skill 这个skill的质量"
+```
+
+Agent会自动：
+- 检查skill的更新历史
+- 分析文档完整性
+- 扫描安全风险
+- 生成质量报告
+
+## Results
+
+```
+📊 Skills质量报告: last30days-skill
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+综合评分: ⭐⭐⭐⭐ 85/100
+
+✅ 更新活跃度: 95分 - 昨天刚更新
+✅ 文档完整度: 90分 - README + SKILL.md 都有
+⚠️ 社区反馈: 70分 - stars不错，但有个open issue
+✅ 代码质量: 85分 - 有测试覆盖
+✅ 安全评分: 80分 - 无明显风险
+
+💡 建议: 可以放心安装，记得看下那个open issue
+```
+
+## Tips
+
+- 评分85+的skills可以放心用
+- 评分70-85的先看文档再决定
+- 评分低于70的建议跳过
+
+## Related
+
+- [GitHub: openclaw-skill-quality-analyzer](https://github.com/jingchang0623-crypto/openclaw-skill-quality-analyzer)
+- [Awesome OpenClaw Skills](https://github.com/VoltAgent/awesome-openclaw-skills)
+- [妙趣AI教程](https://miaoquai.com/tools/)
+
+---
+
+🦞 Contributed by [妙趣AI](https://miaoquai.com)

--- a/usecases/smart-model-router.md
+++ b/usecases/smart-model-router.md
@@ -1,0 +1,59 @@
+# Smart Model Router
+Automatically pick the right model for every task. Save up to 70% on token costs.
+
+What to use it for:
+
+• Complexity-based model selection (fast/balanced/power tiers)
+• Cost optimization for high-volume task processing
+• Routing analytics and savings reports
+• Budget-aware model switching
+
+> Route simple tasks to cheap models, complex tasks to power models. No manual switching needed.
+
+## Skills you Need
+[smart-router](https://github.com/jingchang0623-crypto/openclaw-smart-router) skill.
+
+Install:
+```bash
+git clone https://github.com/jingchang0623-crypto/openclaw-smart-router.git ~/.openclaw/skills/smart-router
+```
+
+Or copy `smart-router.md` to your skills directory.
+
+## How to Set it Up
+After installing, prompt your OpenClaw:
+```text
+When I give you tasks, analyze their complexity (0-10) and tell me which model tier is optimal:
+- Fast (score 0-3): Quick edits, formatting, typos → Haiku/GPT-4o-mini
+- Balanced (score 4-6): Coding, analysis, features → Sonnet/GPT-4o
+- Power (score 7-10): Architecture, research, debugging → Opus/o1
+
+Track your routing decisions. At end of day, show me how much I saved vs using power tier for everything.
+```
+
+## Example Use Case
+```
+User: "Fix typo in README.md"
+Agent: 🎯 Task Analysis:
+- Complexity: 1/10 → Fast tier
+- Model: Claude Haiku
+- Savings: 93% vs Opus
+
+User: "Design microservices architecture for payment system"
+Agent: 🎯 Task Analysis:
+- Complexity: 9/10 → Power tier
+- Model: Claude Opus
+- This is complex work, full power needed
+```
+
+## Cost Savings Example
+For 100 tasks/day, avg 5K tokens:
+- Without routing: $9/day on Sonnet
+- With smart routing: $8.64/day
+- Monthly savings: **$11+** (conservative)
+- High-volume: **40-70% savings**
+
+## Related Resources
+- [openclaw-smart-router GitHub](https://github.com/jingchang0623-crypto/openclaw-smart-router) — Full documentation and CLI
+- [mnfst/manifest](https://github.com/mnfst/manifest) — Inspiration for smart routing
+- [miaoquai.com](https://miaoquai.com/tools/) — More OpenClaw tools by 妙趣AI


### PR DESCRIPTION
## Description
Add a new use case: **Skills Comparer** — a CLI tool to compare 5 major OpenClaw Skills sources and get scenario-based recommendations.

## Skills Sources Covered
- `mattpocock/skills` (84.8k ⭐, engineer-tested)
- `anthropics/skills` (official)
- `VoltAgent/awesome-openclaw-skills` (5400+ curated)
- `K-Dense-AI/scientific-agent-skills` (research/engineering)
- `obra/superpowers` (framework-level)

## Features
- `list <source>` — Show source details (stars, focus, update time)
- `search <source> <query>` — Search within a source
- `compare [sources...]` — Side-by-side comparison table
- `recommend --use-case <case>` — Scenario-based recommendations
- `export --format markdown|json` — Export reports

## Use Cases
- Frontend devs choosing between mattpocock vs anthropics
- Researchers finding K-Dense-AI scientific skills
- General users exploring the 5400+ skills from VoltAgent

## Links
- Tool: https://github.com/jingchang0623-crypto/openclaw-skills-comparer
- Website: https://miaoquai.com

By 妙趣AI 🦞