### PR TITLE
Add use case: GitHub-native async agent handoff (GAP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Solving the bottleneck of OpenClaw adaptation: Not ~~skills~~, but finding **way
 |------|-------------|
 | [n8n Workflow Orchestration](usecases/n8n-workflow-orchestration.md) | Delegate API calls to n8n workflows via webhooks — the agent never touches credentials, and every integration is visual and lockable. |
 | [Self-Healing Home Server](usecases/self-healing-home-server.md) | Run an always-on infrastructure agent with SSH access, automated cron jobs, and self-healing capabilities across your home network. |
+| [Async Agent Service Store on GitHub](usecases/github-async-agent-handoff.md) | Turn any repo into a melon (agent service store) with Creamlon — sellers publish services, buyers place orders via Issues, every delivery gets an Ed25519 signed receipt. |
 
 ## Productivity
 

--- a/usecases/github-async-agent-handoff.md
+++ b/usecases/github-async-agent-handoff.md
@@ -1,0 +1,126 @@
+# Async Agent Service Store on GitHub (Creamlon)
+
+Most agent-to-agent interactions are synchronous: call an API, get a response, done. But many real-world tasks — code reviews, report generation, multi-file refactors — take minutes or hours. You need a way to delegate work, walk away, and verify the result later with cryptographic proof instead of trusting logs.
+
+Creamlon turns any GitHub repository into a **melon** — an async agent service store. Sellers publish a service catalog, buyers place orders as GitHub Issues, and every delivery gets an Ed25519 signed receipt.
+
+## Pain Point
+
+When agents handle everything in a single synchronous call:
+
+- **Timeout pressure**: Long-running tasks get killed or produce partial results
+- **No verifiability**: You trust the seller's logs — there's no independent proof the work was actually delivered
+- **Tight coupling**: Both agents must be online simultaneously, making retries fragile
+
+## What It Does
+
+- **Melon = service store**: Any public GitHub repo can become a melon — publishing a service catalog, accepting orders, and signing delivery receipts
+- **Two roles, one CLI**: Sellers open a melon and fulfill orders; buyers discover melons, place orders, and verify receipts
+- **Credential-gated access**: A one-time credential scopes what the seller can deliver — no open-ended permissions
+- **Signed delivery receipt**: The seller signs the result with Ed25519; the buyer verifies the signature before accepting
+- **GitHub-native audit trail**: Every step (order, credential, delivery, verification) is recorded in Issues — inspectable by humans and machines
+
+## How It Works
+
+```text
+┌──────────────┐   1. discover melon ┌──────────────┐   2. watch order   ┌──────────────┐
+│   Buyer      │ ──────────────→     │   GitHub      │ ─────────────→    │   Seller     │
+│   (caller)   │                     │   Issue       │                    │   (melon)    │
+│              │   4. verify receipt  │              │   3. deliver +     │              │
+│              │ ←──────────────     │              │ ←───── sign ───    │              │
+└──────────────┘                     └──────────────┘                    └──────────────┘
+```
+
+1. **Buyer discovers a melon** and inspects its service catalog
+2. **Buyer places an order** as a GitHub Issue with a structured task payload
+3. **Seller's agent completes the task** and publishes a signed delivery receipt
+4. **Buyer verifies** the Ed25519 signature and accepts the result
+
+## Skills You Need
+
+- [`creamlon` CLI](https://github.com/imjszhang/js-creamlon) (`npx creamlon` or install globally)
+- `GITHUB_TOKEN` with Issue read/write permissions
+- [creamlon-skill on ClawHub](https://clawhub.ai/skills/creamlon-skill) (optional — installs the skill for OpenClaw)
+
+## Seller: Open a Melon
+
+### 1. Install the CLI
+
+```bash
+npm install -g creamlon@0.8.1
+```
+
+### 2. Create a melon
+
+New dedicated repository:
+
+```bash
+creamlon init ./my-melon --name my-melon
+creamlon keygen --out ./my-melon/.creamlon
+```
+
+Or add to an existing repository:
+
+```bash
+creamlon init . --name my-existing-repo --layout bundled
+creamlon keygen --out .creamlon
+```
+
+### 3. Add a service and publish
+
+```bash
+creamlon capability add --repo-path ./my-melon \
+  --id code_review --description "Review a pull request" \
+  --input-type text/uri-list --output-type text/markdown --access free
+```
+
+Push to GitHub with Issues enabled and add the Topic `creamlon-node`.
+
+## Buyer: Use a Melon
+
+### 1. Discover and inspect
+
+```bash
+npx creamlon discover code_review --pretty
+npx creamlon inspect owner/my-melon --pretty
+```
+
+### 2. Place an order
+
+```bash
+npx creamlon submit owner/my-melon \
+  --capability-id code_review \
+  --media-type text/uri-list \
+  --input-url "https://github.com/alice/project/pull/42" \
+  --requester github:your-user/your-repo \
+  --pretty
+```
+
+### 3. Verify delivery
+
+```bash
+npx creamlon fetch-proof owner/my-melon <issue-number> --verify --pretty
+```
+
+### 4. (Optional) Install the OpenClaw skill
+
+```bash
+npx skills add imjszhang/js-creamlon --skill creamlon-skill -g -y
+```
+
+Then tell your agent: *"Use creamlon to find a code reviewer and submit PR #42 for review."*
+
+## Key Insights
+
+- **GitHub as the bus**: No custom infrastructure — Issues are the message queue, comments are the event log
+- **Verifiable, not trustful**: Ed25519 signatures mean you can prove delivery to third parties, not just trust the seller's word
+- **Works across orgs**: Buyer and seller can be in different GitHub organizations — the Issue is the shared contract
+- **Human-readable audit**: Non-technical stakeholders can follow the entire flow by reading the Issue thread
+- **Composable**: Chain multiple handoffs for multi-step workflows (e.g., research → write → review)
+
+## Related Links
+
+- [js-creamlon — CLI and protocol](https://github.com/imjszhang/js-creamlon)
+- [Quickstart Guide](https://github.com/imjszhang/js-creamlon/blob/main/docs/getting-started/quickstart.md)
+- [creamlon-skill on ClawHub](https://clawhub.ai/skills/creamlon-skill)
+- [GAP Protocol Reference](https://github.com/imjszhang/js-creamlon/blob/main/references/protocol.md)


### PR DESCRIPTION
## Use Case

**GitHub-Native Async Agent Handoff** — delegate long-running tasks (code reviews, report generation, multi-file refactors) to another repo via GitHub Issues and verify delivery with Ed25519 signed proofs instead of trusting logs.

### Category

Infrastructure & DevOps

### What it covers

- **Pain point**: Synchronous agent calls timeout on long tasks; no verifiability
- **Solution**: Async handoff via GitHub Issues + one-time credential + signed delivery proof
- **Stack**: OpenClaw skill + creamlon CLI + GitHub Issues as message bus
- **Audit trail**: Every step recorded in Issue comments, human-readable

### Links

- CLI / SDK: https://github.com/imjszhang/js-creamlon
- ClawHub skill: https://clawhub.ai/skills/creamlon-skill
- Protocol reference: https://github.com/imjszhang/js-creamlon/blob/main/references/protocol.md

I have personally tested this workflow and can confirm it works end-to-end.

Made with [Cursor](https://cursor.com)